### PR TITLE
🔀 :: (#42) 커뮤니티 목록 서버 연동

### DIFF
--- a/data/src/main/kotlin/com/signal/data/api/ApiProvider.kt
+++ b/data/src/main/kotlin/com/signal/data/api/ApiProvider.kt
@@ -18,11 +18,15 @@ object ApiProvider {
     ): Retrofit {
         return retrofit ?: Retrofit.Builder().baseUrl("http://54.152.35.68:8080/").client(
             OkHttpClient.Builder().addInterceptor(tokenInterceptor)
-                .addInterceptor(getLoggingInterceptor()).build()
+                .addInterceptor(getLoggingInterceptor()).build(),
         ).addConverterFactory(GsonConverterFactory.create()).build()
     }
 
-    fun getUserApi(
-        tokenInterceptor: TokenInterceptor,
-    ): UserApi = getRetrofit(tokenInterceptor).create(UserApi::class.java)
+    fun getUserApi(tokenInterceptor: TokenInterceptor): UserApi {
+        return getRetrofit(tokenInterceptor).create(UserApi::class.java)
+    }
+
+    fun getFeedApi(tokenInterceptor: TokenInterceptor): FeedApi {
+        return getRetrofit(tokenInterceptor).create(FeedApi::class.java)
+    }
 }

--- a/data/src/main/kotlin/com/signal/data/api/FeedApi.kt
+++ b/data/src/main/kotlin/com/signal/data/api/FeedApi.kt
@@ -1,0 +1,14 @@
+package com.signal.data.api
+
+import com.signal.data.model.feed.FetchPostsResponse
+import com.signal.domain.enums.Tag
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface FeedApi {
+    @GET(SignalUrl.Feed.List)
+    suspend fun fetchPosts(
+        @Query("tag") tag: Tag,
+        @Query("pagenum") pageNum: Long,
+    ): FetchPostsResponse
+}

--- a/data/src/main/kotlin/com/signal/data/api/FeedApi.kt
+++ b/data/src/main/kotlin/com/signal/data/api/FeedApi.kt
@@ -1,8 +1,11 @@
 package com.signal.data.api
 
-import com.signal.data.model.feed.FetchPostsResponse
+import com.signal.data.model.feed.request.PostRequest
+import com.signal.data.model.feed.response.FetchPostsResponse
 import com.signal.domain.enums.Tag
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Query
 
 interface FeedApi {
@@ -11,4 +14,9 @@ interface FeedApi {
         @Query("tag") tag: Tag,
         @Query("pagenum") pageNum: Long,
     ): FetchPostsResponse
+
+    @POST(SignalUrl.Feed.Post)
+    suspend fun post(
+        @Body postRequest: PostRequest,
+    )
 }

--- a/data/src/main/kotlin/com/signal/data/api/FeedApi.kt
+++ b/data/src/main/kotlin/com/signal/data/api/FeedApi.kt
@@ -1,11 +1,13 @@
 package com.signal.data.api
 
 import com.signal.data.model.feed.request.PostRequest
+import com.signal.data.model.feed.response.FetchPostDetailsResponse
 import com.signal.data.model.feed.response.FetchPostsResponse
 import com.signal.domain.enums.Tag
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface FeedApi {
@@ -19,4 +21,9 @@ interface FeedApi {
     suspend fun post(
         @Body postRequest: PostRequest,
     )
+
+    @GET(SignalUrl.Feed.Post)
+    suspend fun fetchPostDetails(
+        @Path("feed_id") feedId: Long,
+    ): FetchPostDetailsResponse
 }

--- a/data/src/main/kotlin/com/signal/data/api/FeedApi.kt
+++ b/data/src/main/kotlin/com/signal/data/api/FeedApi.kt
@@ -18,7 +18,7 @@ interface FeedApi {
     ): FetchPostsResponse
 
     @POST(SignalUrl.Feed.Post)
-    suspend fun post(
+    suspend fun createPost(
         @Body postRequest: PostRequest,
     )
 

--- a/data/src/main/kotlin/com/signal/data/api/FeedApi.kt
+++ b/data/src/main/kotlin/com/signal/data/api/FeedApi.kt
@@ -17,12 +17,12 @@ interface FeedApi {
         @Query("pagenum") pageNum: Long,
     ): FetchPostsResponse
 
-    @POST(SignalUrl.Feed.Post)
+    @POST(SignalUrl.Feed.CreatePost)
     suspend fun createPost(
         @Body postRequest: PostRequest,
     )
 
-    @GET(SignalUrl.Feed.Post)
+    @GET(SignalUrl.Feed.CreatePost)
     suspend fun fetchPostDetails(
         @Path("feed_id") feedId: Long,
     ): FetchPostDetailsResponse

--- a/data/src/main/kotlin/com/signal/data/api/SignalUrl.kt
+++ b/data/src/main/kotlin/com/signal/data/api/SignalUrl.kt
@@ -2,11 +2,16 @@ package com.signal.data.api
 
 object SignalUrl {
     private const val users = "/users"
+    private const val feed = "/feed"
 
     object Users {
         const val SignIn = "$users/signin"
         const val SignUp = "$users/signup"
         const val Secession = "$users/secession"
         const val FetchUserInformation = "$users/info"
+    }
+
+    object Feed {
+        const val List = "$feed/list"
     }
 }

--- a/data/src/main/kotlin/com/signal/data/api/SignalUrl.kt
+++ b/data/src/main/kotlin/com/signal/data/api/SignalUrl.kt
@@ -12,6 +12,7 @@ object SignalUrl {
     }
 
     object Feed {
+        const val Post = feed
         const val List = "$feed/list"
     }
 }

--- a/data/src/main/kotlin/com/signal/data/api/SignalUrl.kt
+++ b/data/src/main/kotlin/com/signal/data/api/SignalUrl.kt
@@ -12,7 +12,7 @@ object SignalUrl {
     }
 
     object Feed {
-        const val Post = feed
+        const val CreatePost = "$feed/user"
         const val List = "$feed/list"
     }
 }

--- a/data/src/main/kotlin/com/signal/data/datasource/feed/FeedDataSource.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/feed/FeedDataSource.kt
@@ -11,7 +11,7 @@ interface FeedDataSource {
         pageNum: Long,
     ): FetchPostsResponse
 
-    suspend fun post(postRequest: PostRequest)
+    suspend fun createPost(postRequest: PostRequest)
 
     suspend fun fetchPostDetails(feedId: Long): FetchPostDetailsResponse
 }

--- a/data/src/main/kotlin/com/signal/data/datasource/feed/FeedDataSource.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/feed/FeedDataSource.kt
@@ -1,6 +1,7 @@
 package com.signal.data.datasource.feed
 
-import com.signal.data.model.feed.FetchPostsResponse
+import com.signal.data.model.feed.request.PostRequest
+import com.signal.data.model.feed.response.FetchPostsResponse
 import com.signal.domain.enums.Tag
 
 interface FeedDataSource {
@@ -8,4 +9,6 @@ interface FeedDataSource {
         tag: Tag,
         pageNum: Long,
     ): FetchPostsResponse
+
+    suspend fun post(postRequest: PostRequest)
 }

--- a/data/src/main/kotlin/com/signal/data/datasource/feed/FeedDataSource.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/feed/FeedDataSource.kt
@@ -1,6 +1,7 @@
 package com.signal.data.datasource.feed
 
 import com.signal.data.model.feed.request.PostRequest
+import com.signal.data.model.feed.response.FetchPostDetailsResponse
 import com.signal.data.model.feed.response.FetchPostsResponse
 import com.signal.domain.enums.Tag
 
@@ -11,4 +12,6 @@ interface FeedDataSource {
     ): FetchPostsResponse
 
     suspend fun post(postRequest: PostRequest)
+
+    suspend fun fetchPostDetails(feedId: Long): FetchPostDetailsResponse
 }

--- a/data/src/main/kotlin/com/signal/data/datasource/feed/FeedDataSource.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/feed/FeedDataSource.kt
@@ -1,0 +1,11 @@
+package com.signal.data.datasource.feed
+
+import com.signal.data.model.feed.FetchPostsResponse
+import com.signal.domain.enums.Tag
+
+interface FeedDataSource {
+    suspend fun fetchPosts(
+        tag: Tag,
+        pageNum: Long,
+    ): FetchPostsResponse
+}

--- a/data/src/main/kotlin/com/signal/data/datasource/feed/FeedDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/feed/FeedDataSourceImpl.kt
@@ -20,8 +20,8 @@ class FeedDataSourceImpl(
         )
     }.sendRequest()
 
-    override suspend fun post(postRequest: PostRequest) = ExceptionHandler<Unit>().httpRequest {
-        feedApi.post(postRequest)
+    override suspend fun createPost(postRequest: PostRequest) = ExceptionHandler<Unit>().httpRequest {
+        feedApi.createPost(postRequest)
     }.sendRequest()
 
     override suspend fun fetchPostDetails(feedId: Long) =

--- a/data/src/main/kotlin/com/signal/data/datasource/feed/FeedDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/feed/FeedDataSourceImpl.kt
@@ -1,7 +1,8 @@
 package com.signal.data.datasource.feed
 
 import com.signal.data.api.FeedApi
-import com.signal.data.model.feed.FetchPostsResponse
+import com.signal.data.model.feed.request.PostRequest
+import com.signal.data.model.feed.response.FetchPostsResponse
 import com.signal.data.util.ExceptionHandler
 import com.signal.domain.enums.Tag
 
@@ -16,5 +17,9 @@ class FeedDataSourceImpl(
             tag = tag,
             pageNum = pageNum,
         )
+    }.sendRequest()
+
+    override suspend fun post(postRequest: PostRequest) = ExceptionHandler<Unit>().httpRequest {
+        feedApi.post(postRequest)
     }.sendRequest()
 }

--- a/data/src/main/kotlin/com/signal/data/datasource/feed/FeedDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/feed/FeedDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.signal.data.datasource.feed
 
 import com.signal.data.api.FeedApi
 import com.signal.data.model.feed.request.PostRequest
+import com.signal.data.model.feed.response.FetchPostDetailsResponse
 import com.signal.data.model.feed.response.FetchPostsResponse
 import com.signal.data.util.ExceptionHandler
 import com.signal.domain.enums.Tag
@@ -22,4 +23,9 @@ class FeedDataSourceImpl(
     override suspend fun post(postRequest: PostRequest) = ExceptionHandler<Unit>().httpRequest {
         feedApi.post(postRequest)
     }.sendRequest()
+
+    override suspend fun fetchPostDetails(feedId: Long) =
+        ExceptionHandler<FetchPostDetailsResponse>().httpRequest {
+            feedApi.fetchPostDetails(feedId = feedId)
+        }.sendRequest()
 }

--- a/data/src/main/kotlin/com/signal/data/datasource/feed/FeedDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/feed/FeedDataSourceImpl.kt
@@ -1,0 +1,20 @@
+package com.signal.data.datasource.feed
+
+import com.signal.data.api.FeedApi
+import com.signal.data.model.feed.FetchPostsResponse
+import com.signal.data.util.ExceptionHandler
+import com.signal.domain.enums.Tag
+
+class FeedDataSourceImpl(
+    private val feedApi: FeedApi,
+) : FeedDataSource {
+    override suspend fun fetchPosts(
+        tag: Tag,
+        pageNum: Long,
+    ): FetchPostsResponse = ExceptionHandler<FetchPostsResponse>().httpRequest {
+        feedApi.fetchPosts(
+            tag = tag,
+            pageNum = pageNum,
+        )
+    }.sendRequest()
+}

--- a/data/src/main/kotlin/com/signal/data/model/feed/FetchPostsResponse.kt
+++ b/data/src/main/kotlin/com/signal/data/model/feed/FetchPostsResponse.kt
@@ -1,0 +1,28 @@
+package com.signal.data.model.feed
+
+import com.google.gson.annotations.SerializedName
+import com.signal.domain.PostsEntity
+
+data class FetchPostsResponse(
+    @SerializedName("feed") val posts: List<Post>,
+) {
+    data class Post(
+        @SerializedName("id") val id: Long,
+        @SerializedName("img") val img: String,
+        @SerializedName("title") val title: String,
+        @SerializedName("date") val date: String,
+        @SerializedName("user") val user: String,
+    )
+}
+
+fun FetchPostsResponse.toEntity() = PostsEntity(
+    postEntities = this.posts.map { it.toEntity() },
+)
+
+private fun FetchPostsResponse.Post.toEntity() = PostsEntity.PostEntity(
+    id = this.id,
+    img = this.img,
+    title = this.title,
+    date = this.date,
+    user = this.user,
+)

--- a/data/src/main/kotlin/com/signal/data/model/feed/request/PostRequest.kt
+++ b/data/src/main/kotlin/com/signal/data/model/feed/request/PostRequest.kt
@@ -1,0 +1,8 @@
+package com.signal.data.model.feed.request
+
+import com.google.gson.annotations.SerializedName
+
+data class PostRequest(
+    @SerializedName("title") val title: String,
+    @SerializedName("content") val content: String,
+)

--- a/data/src/main/kotlin/com/signal/data/model/feed/request/PostRequest.kt
+++ b/data/src/main/kotlin/com/signal/data/model/feed/request/PostRequest.kt
@@ -1,9 +1,11 @@
 package com.signal.data.model.feed.request
 
 import com.google.gson.annotations.SerializedName
+import com.signal.domain.enums.Tag
 
 data class PostRequest(
     @SerializedName("title") val title: String,
     @SerializedName("content") val content: String,
     @SerializedName("image") val image: String,
+    @SerializedName("tag") val tag: Tag,
 )

--- a/data/src/main/kotlin/com/signal/data/model/feed/request/PostRequest.kt
+++ b/data/src/main/kotlin/com/signal/data/model/feed/request/PostRequest.kt
@@ -5,4 +5,5 @@ import com.google.gson.annotations.SerializedName
 data class PostRequest(
     @SerializedName("title") val title: String,
     @SerializedName("content") val content: String,
+    @SerializedName("image") val image: String,
 )

--- a/data/src/main/kotlin/com/signal/data/model/feed/response/FetchPostDetailsResponse.kt
+++ b/data/src/main/kotlin/com/signal/data/model/feed/response/FetchPostDetailsResponse.kt
@@ -1,0 +1,12 @@
+package com.signal.data.model.feed.response
+
+import com.google.gson.annotations.SerializedName
+
+data class FetchPostDetailsResponse(
+    @SerializedName("img") val imageUrl: String,
+    @SerializedName("title") val title: String,
+    @SerializedName("date") val date: String,
+    @SerializedName("writer") val writer: String,
+    @SerializedName("content") val content: String,
+    @SerializedName("isMine") val isMine: Boolean,
+)

--- a/data/src/main/kotlin/com/signal/data/model/feed/response/FetchPostDetailsResponse.kt
+++ b/data/src/main/kotlin/com/signal/data/model/feed/response/FetchPostDetailsResponse.kt
@@ -9,6 +9,7 @@ data class FetchPostDetailsResponse(
     @SerializedName("date") val date: String,
     @SerializedName("writer") val writer: String,
     @SerializedName("content") val content: String,
+    @SerializedName("profile") val profile: String?,
     @SerializedName("isMine") val isMine: Boolean,
 )
 
@@ -18,5 +19,6 @@ fun FetchPostDetailsResponse.toEntity() = PostDetailsEntity(
     date = this.date,
     writer = this.writer,
     content = this.content,
+    profile = this.profile,
     isMine = this.isMine,
 )

--- a/data/src/main/kotlin/com/signal/data/model/feed/response/FetchPostDetailsResponse.kt
+++ b/data/src/main/kotlin/com/signal/data/model/feed/response/FetchPostDetailsResponse.kt
@@ -1,12 +1,22 @@
 package com.signal.data.model.feed.response
 
 import com.google.gson.annotations.SerializedName
+import com.signal.domain.entity.PostDetailsEntity
 
 data class FetchPostDetailsResponse(
-    @SerializedName("img") val imageUrl: String,
+    @SerializedName("img") val imageUrl: String?,
     @SerializedName("title") val title: String,
     @SerializedName("date") val date: String,
     @SerializedName("writer") val writer: String,
     @SerializedName("content") val content: String,
     @SerializedName("isMine") val isMine: Boolean,
+)
+
+fun FetchPostDetailsResponse.toEntity() = PostDetailsEntity(
+    imageUrl = this.imageUrl,
+    title = this.title,
+    date = this.date,
+    writer = this.writer,
+    content = this.content,
+    isMine = this.isMine,
 )

--- a/data/src/main/kotlin/com/signal/data/model/feed/response/FetchPostsResponse.kt
+++ b/data/src/main/kotlin/com/signal/data/model/feed/response/FetchPostsResponse.kt
@@ -1,4 +1,4 @@
-package com.signal.data.model.feed
+package com.signal.data.model.feed.response
 
 import com.google.gson.annotations.SerializedName
 import com.signal.domain.PostsEntity

--- a/data/src/main/kotlin/com/signal/data/repository/FeedRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/repository/FeedRepositoryImpl.kt
@@ -21,11 +21,13 @@ class FeedRepositoryImpl(
     override suspend fun post(
         title: String,
         content: String,
+        image: String,
     ) = runCatching {
         feedDataSource.post(
             PostRequest(
                 title = title,
                 content = content,
+                image = image,
             ),
         )
     }

--- a/data/src/main/kotlin/com/signal/data/repository/FeedRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/repository/FeedRepositoryImpl.kt
@@ -22,12 +22,14 @@ class FeedRepositoryImpl(
         title: String,
         content: String,
         image: String,
+        tag: Tag,
     ) = runCatching {
         feedDataSource.post(
             PostRequest(
                 title = title,
                 content = content,
                 image = image,
+                tag = tag,
             ),
         )
     }

--- a/data/src/main/kotlin/com/signal/data/repository/FeedRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/repository/FeedRepositoryImpl.kt
@@ -18,13 +18,13 @@ class FeedRepositoryImpl(
         pageNum = pageNum,
     ).toEntity()
 
-    override suspend fun post(
+    override suspend fun createPost(
         title: String,
         content: String,
         image: String,
         tag: Tag,
     ) = runCatching {
-        feedDataSource.post(
+        feedDataSource.createPost(
             PostRequest(
                 title = title,
                 content = content,

--- a/data/src/main/kotlin/com/signal/data/repository/FeedRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/repository/FeedRepositoryImpl.kt
@@ -1,7 +1,8 @@
 package com.signal.data.repository
 
 import com.signal.data.datasource.feed.FeedDataSource
-import com.signal.data.model.feed.toEntity
+import com.signal.data.model.feed.request.PostRequest
+import com.signal.data.model.feed.response.toEntity
 import com.signal.domain.PostsEntity
 import com.signal.domain.enums.Tag
 import com.signal.domain.repository.FeedRepository
@@ -16,4 +17,16 @@ class FeedRepositoryImpl(
         tag = tag,
         pageNum = pageNum,
     ).toEntity()
+
+    override suspend fun post(
+        title: String,
+        content: String,
+    ) = runCatching {
+        feedDataSource.post(
+            PostRequest(
+                title = title,
+                content = content,
+            ),
+        )
+    }
 }

--- a/data/src/main/kotlin/com/signal/data/repository/FeedRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/repository/FeedRepositoryImpl.kt
@@ -29,4 +29,8 @@ class FeedRepositoryImpl(
             ),
         )
     }
+
+    override suspend fun fetchPostDetails(feedId: Long) = runCatching {
+        feedDataSource.fetchPostDetails(feedId = feedId).toEntity()
+    }
 }

--- a/data/src/main/kotlin/com/signal/data/repository/FeedRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/repository/FeedRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.signal.data.repository
+
+import com.signal.data.datasource.feed.FeedDataSource
+import com.signal.data.model.feed.toEntity
+import com.signal.domain.PostsEntity
+import com.signal.domain.enums.Tag
+import com.signal.domain.repository.FeedRepository
+
+class FeedRepositoryImpl(
+    private val feedDataSource: FeedDataSource,
+) : FeedRepository {
+    override suspend fun fetchPosts(
+        tag: Tag,
+        pageNum: Long,
+    ): PostsEntity = feedDataSource.fetchPosts(
+        tag = tag,
+        pageNum = pageNum,
+    ).toEntity()
+}

--- a/data/src/main/kotlin/com/signal/data/util/TokenInterceptor.kt
+++ b/data/src/main/kotlin/com/signal/data/util/TokenInterceptor.kt
@@ -14,6 +14,7 @@ class TokenInterceptor(
 
         val ignorePaths = listOf(
             SignalUrl.Users.SignIn,
+            SignalUrl.Users.SignUp,
         )
 
         if (ignorePaths.contains(path)) {

--- a/domain/src/main/kotlin/com/signal/domain/PostsEntity.kt
+++ b/domain/src/main/kotlin/com/signal/domain/PostsEntity.kt
@@ -1,0 +1,13 @@
+package com.signal.domain
+
+data class PostsEntity(
+    val postEntities: List<PostEntity>,
+) {
+    data class PostEntity(
+        val id: Long,
+        val img: String,
+        val title: String,
+        val date: String,
+        val user: String,
+    )
+}

--- a/domain/src/main/kotlin/com/signal/domain/entity/PostDetailsEntity.kt
+++ b/domain/src/main/kotlin/com/signal/domain/entity/PostDetailsEntity.kt
@@ -6,5 +6,6 @@ data class PostDetailsEntity(
     val date: String,
     val writer: String,
     val content: String,
+    val profile: String?,
     val isMine: Boolean,
 )

--- a/domain/src/main/kotlin/com/signal/domain/entity/PostDetailsEntity.kt
+++ b/domain/src/main/kotlin/com/signal/domain/entity/PostDetailsEntity.kt
@@ -1,0 +1,10 @@
+package com.signal.domain.entity
+
+data class PostDetailsEntity(
+    val imageUrl: String?,
+    val title: String,
+    val date: String,
+    val writer: String,
+    val content: String,
+    val isMine: Boolean,
+)

--- a/domain/src/main/kotlin/com/signal/domain/enums/Tag.kt
+++ b/domain/src/main/kotlin/com/signal/domain/enums/Tag.kt
@@ -1,0 +1,6 @@
+package com.signal.domain.enums
+
+enum class Tag {
+    GENERAL,
+    NOTIFICATION,
+}

--- a/domain/src/main/kotlin/com/signal/domain/repository/FeedRepository.kt
+++ b/domain/src/main/kotlin/com/signal/domain/repository/FeedRepository.kt
@@ -10,7 +10,7 @@ interface FeedRepository {
         pageNum: Long,
     ): PostsEntity
 
-    suspend fun post(
+    suspend fun createPost(
         title: String,
         content: String,
         image: String,

--- a/domain/src/main/kotlin/com/signal/domain/repository/FeedRepository.kt
+++ b/domain/src/main/kotlin/com/signal/domain/repository/FeedRepository.kt
@@ -13,6 +13,7 @@ interface FeedRepository {
     suspend fun post(
         title: String,
         content: String,
+        image: String,
     ): Result<Unit>
 
     suspend fun fetchPostDetails(feedId: Long): Result<PostDetailsEntity>

--- a/domain/src/main/kotlin/com/signal/domain/repository/FeedRepository.kt
+++ b/domain/src/main/kotlin/com/signal/domain/repository/FeedRepository.kt
@@ -14,6 +14,7 @@ interface FeedRepository {
         title: String,
         content: String,
         image: String,
+        tag: Tag,
     ): Result<Unit>
 
     suspend fun fetchPostDetails(feedId: Long): Result<PostDetailsEntity>

--- a/domain/src/main/kotlin/com/signal/domain/repository/FeedRepository.kt
+++ b/domain/src/main/kotlin/com/signal/domain/repository/FeedRepository.kt
@@ -1,6 +1,7 @@
 package com.signal.domain.repository
 
 import com.signal.domain.PostsEntity
+import com.signal.domain.entity.PostDetailsEntity
 import com.signal.domain.enums.Tag
 
 interface FeedRepository {
@@ -13,4 +14,6 @@ interface FeedRepository {
         title: String,
         content: String,
     ): Result<Unit>
+
+    suspend fun fetchPostDetails(feedId: Long): Result<PostDetailsEntity>
 }

--- a/domain/src/main/kotlin/com/signal/domain/repository/FeedRepository.kt
+++ b/domain/src/main/kotlin/com/signal/domain/repository/FeedRepository.kt
@@ -8,4 +8,9 @@ interface FeedRepository {
         tag: Tag,
         pageNum: Long,
     ): PostsEntity
+
+    suspend fun post(
+        title: String,
+        content: String,
+    ): Result<Unit>
 }

--- a/domain/src/main/kotlin/com/signal/domain/repository/FeedRepository.kt
+++ b/domain/src/main/kotlin/com/signal/domain/repository/FeedRepository.kt
@@ -1,0 +1,11 @@
+package com.signal.domain.repository
+
+import com.signal.domain.PostsEntity
+import com.signal.domain.enums.Tag
+
+interface FeedRepository {
+    suspend fun fetchPosts(
+        tag: Tag,
+        pageNum: Long,
+    ): PostsEntity
+}

--- a/presentation/src/main/java/com/signal/signal_android/SignalApplication.kt
+++ b/presentation/src/main/java/com/signal/signal_android/SignalApplication.kt
@@ -2,18 +2,23 @@ package com.signal.signal_android
 
 import android.app.Application
 import com.signal.data.api.ApiProvider
+import com.signal.data.datasource.feed.FeedDataSource
+import com.signal.data.datasource.feed.FeedDataSourceImpl
 import com.signal.data.datasource.user.local.LocalUserDataSource
 import com.signal.data.datasource.user.local.LocalUserDataSourceImpl
 import com.signal.data.datasource.user.remote.RemoteUserDataSource
 import com.signal.data.datasource.user.remote.RemoteUserDataSourceImpl
+import com.signal.data.repository.FeedRepositoryImpl
 import com.signal.data.repository.UserRepositoryImpl
 import com.signal.data.util.TokenInterceptor
+import com.signal.domain.repository.FeedRepository
 import com.signal.domain.repository.UserRepository
 import com.signal.domain.usecase.users.FetchUserInformationUseCase
 import com.signal.domain.usecase.users.SecessionUseCase
 import com.signal.domain.usecase.users.SignInUseCase
 import com.signal.domain.usecase.users.SignOutUseCase
 import com.signal.domain.usecase.users.SignUpUseCase
+import com.signal.signal_android.feature.main.feed.FeedViewModel
 import com.signal.signal_android.feature.mypage.MyPageViewModel
 import com.signal.signal_android.feature.signin.SignInViewModel
 import com.signal.signal_android.feature.signup.SignUpViewModel
@@ -49,12 +54,14 @@ val apiModule: Module
     get() = module {
         single { TokenInterceptor(localUserDataSource = get()) }
         single { ApiProvider.getUserApi(tokenInterceptor = get()) }
+        single { ApiProvider.getFeedApi(tokenInterceptor = get()) }
     }
 
 val dataSourceModule: Module
     get() = module {
         single<RemoteUserDataSource> { RemoteUserDataSourceImpl(userApi = get()) }
         single<LocalUserDataSource> { LocalUserDataSourceImpl(context = androidContext()) }
+        single<FeedDataSource> { FeedDataSourceImpl(feedApi = get()) }
     }
 
 val repositoryModule: Module
@@ -64,6 +71,9 @@ val repositoryModule: Module
                 remoteUserDataSource = get(),
                 localUserDataSource = get(),
             )
+        }
+        single<FeedRepository> {
+            FeedRepositoryImpl(feedDataSource = get())
         }
     }
 
@@ -87,4 +97,5 @@ val viewModelModule: Module
                 fetchUserInformationUseCase = get(),
             )
         }
+        viewModel { FeedViewModel(feedRepository = get()) }
     }

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/CreatePost.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/CreatePost.kt
@@ -12,10 +12,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -28,13 +26,14 @@ import com.signal.signal_android.designsystem.component.Header
 import com.signal.signal_android.designsystem.foundation.SignalColor
 import com.signal.signal_android.designsystem.textfield.SignalTextField
 import com.signal.signal_android.designsystem.util.signalClickable
+import org.koin.androidx.compose.koinViewModel
 
 @Composable
 internal fun CreatePost(
     moveToBack: () -> Unit,
+    feedViewModel: FeedViewModel = koinViewModel(),
 ) {
-    var title by remember { mutableStateOf("") }
-    var content by remember { mutableStateOf("") }
+    val state by feedViewModel.state.collectAsState()
 
     Column(
         modifier = Modifier
@@ -47,10 +46,8 @@ internal fun CreatePost(
         )
         Spacer(modifier = Modifier.height(4.dp))
         SignalTextField(
-            value = title,
-            onValueChange = {
-                title = it
-            },
+            value = state.title,
+            onValueChange = feedViewModel::setTitle,
             hint = stringResource(id = R.string.create_post_title_hint),
             title = stringResource(id = R.string.create_post_title),
             showLength = true,
@@ -59,10 +56,8 @@ internal fun CreatePost(
         Spacer(modifier = Modifier.height(8.dp))
         SignalTextField(
             modifier = Modifier.fillMaxHeight(0.5f),
-            value = content,
-            onValueChange = {
-                content = it
-            },
+            value = state.content,
+            onValueChange = feedViewModel::setContent,
             hint = stringResource(id = R.string.create_post_content_hint),
             title = stringResource(id = R.string.create_post_content),
             alignment = Alignment.Top,
@@ -74,7 +69,7 @@ internal fun CreatePost(
         Spacer(modifier = Modifier.weight(1f))
         SignalFilledButton(
             text = stringResource(id = R.string.my_page_secession_check),
-            onClick = { /*TODO*/ },
+            onClick = feedViewModel::post,
         )
         Spacer(modifier = Modifier.height(26.dp))
     }

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/CreatePost.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/CreatePost.kt
@@ -69,7 +69,7 @@ internal fun CreatePost(
         Spacer(modifier = Modifier.weight(1f))
         SignalFilledButton(
             text = stringResource(id = R.string.my_page_secession_check),
-            onClick = feedViewModel::post,
+            onClick = feedViewModel::createPost,
         )
         Spacer(modifier = Modifier.height(26.dp))
     }

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/Feed.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/Feed.kt
@@ -1,12 +1,14 @@
 package com.signal.signal_android.feature.main.feed
 
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -116,11 +118,24 @@ internal fun Feed(
                     onDelete = { showDialog = true },
                 )
                 Column(
-                    modifier = Modifier.alpha(alpha),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .fillMaxHeight(0.7f)
+                        .alpha(alpha),
                     horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalArrangement = Arrangement.Center,
                 ) {
-                    SubTitle(text = stringResource(id = R.string.feed_posts_is_empty))
+                    Image(
+                        modifier = Modifier
+                            .fillMaxSize(0.3f)
+                            .padding(bottom = 8.dp),
+                        painter = painterResource(id = R.drawable.ic_surprised),
+                        contentDescription = stringResource(id = R.string.emotion_surprised),
+                    )
+                    SubTitle(
+                        modifier = Modifier.padding(bottom = 4.dp),
+                        text = stringResource(id = R.string.feed_posts_is_empty),
+                    )
                     Body(
                         modifier = Modifier.signalClickable(onClick = moveToCreatePost),
                         text = stringResource(id = R.string.feed_posts_add),

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedDetails.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedDetails.kt
@@ -114,9 +114,9 @@ internal fun FeedDetails(
                     .verticalScroll(rememberScrollState()),
             ) {
                 User(
-                    profileImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/9/95/Instagram_logo_2022.svg/640px-Instagram_logo_2022.svg.png",
-                    name = "승훈티비",
-                    date = "2023-10-10",
+                    profileImageUrl = details.profile!!,
+                    name = details.writer,
+                    date = details.date,
                     onClick = { expanded = feedId },
                     expanded = expanded == feedId,
                     onDismissRequest = { expanded = -1 },
@@ -189,7 +189,7 @@ private fun User(
     expanded: Boolean,
     onDismissRequest: () -> Unit,
 
-) {
+    ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedDetails.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedDetails.kt
@@ -114,7 +114,7 @@ internal fun FeedDetails(
                     .verticalScroll(rememberScrollState()),
             ) {
                 User(
-                    profileImageUrl = details.profile!!,
+                    profileImageUrl = details.profile,
                     name = details.writer,
                     date = details.date,
                     onClick = { expanded = feedId },
@@ -182,7 +182,7 @@ internal fun FeedDetails(
 
 @Composable
 private fun User(
-    profileImageUrl: String,
+    profileImageUrl: String?,
     name: String,
     date: String,
     onClick: () -> Unit,

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedSideEffect.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedSideEffect.kt
@@ -1,0 +1,5 @@
+package com.signal.signal_android.feature.main.feed
+
+sealed interface FeedSideEffect {
+    object PostSuccess : FeedSideEffect
+}

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedState.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedState.kt
@@ -8,6 +8,8 @@ data class FeedState(
     val tag: Tag,
     val pageNum: Long,
     val isPostsEmpty: Boolean,
+    val title: String,
+    val content: String,
 ) {
     companion object {
         fun getDefaultState() = FeedState(
@@ -15,6 +17,8 @@ data class FeedState(
             tag = Tag.GENERAL,
             pageNum = 1,
             isPostsEmpty = false,
+            title = "",
+            content = "",
         )
     }
 }

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedState.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedState.kt
@@ -13,6 +13,7 @@ data class FeedState(
     val content: String,
     val postDetailsEntity: PostDetailsEntity,
     val feedId: Long,
+    val image: String,
 ) {
     companion object {
         fun getDefaultState() = FeedState(
@@ -32,6 +33,7 @@ data class FeedState(
                 isMine = false,
             ),
             feedId = 0L,
+            image = "",
         )
     }
 }

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedState.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedState.kt
@@ -1,6 +1,7 @@
 package com.signal.signal_android.feature.main.feed
 
 import com.signal.domain.PostsEntity
+import com.signal.domain.entity.PostDetailsEntity
 import com.signal.domain.enums.Tag
 
 data class FeedState(
@@ -10,6 +11,8 @@ data class FeedState(
     val isPostsEmpty: Boolean,
     val title: String,
     val content: String,
+    val postDetailsEntity: PostDetailsEntity,
+    val feedId: Long,
 ) {
     companion object {
         fun getDefaultState() = FeedState(
@@ -19,6 +22,15 @@ data class FeedState(
             isPostsEmpty = false,
             title = "",
             content = "",
+            postDetailsEntity = PostDetailsEntity(
+                imageUrl = null,
+                title = "",
+                date = "",
+                writer = "",
+                content = "",
+                isMine = false,
+            ),
+            feedId = 0L,
         )
     }
 }

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedState.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedState.kt
@@ -19,7 +19,7 @@ data class FeedState(
             posts = listOf(),
             tag = Tag.GENERAL,
             pageNum = 1,
-            isPostsEmpty = false,
+            isPostsEmpty = true,
             title = "",
             content = "",
             postDetailsEntity = PostDetailsEntity(

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedState.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedState.kt
@@ -28,6 +28,7 @@ data class FeedState(
                 date = "",
                 writer = "",
                 content = "",
+                profile = "https://github.com/Team-SIGNAL/SIGNAL-ANDROID/blob/develop/presentation/src/main/res/drawable/ic_profile_image.png?raw=true",
                 isMine = false,
             ),
             feedId = 0L,

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedState.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedState.kt
@@ -1,0 +1,20 @@
+package com.signal.signal_android.feature.main.feed
+
+import com.signal.domain.PostsEntity
+import com.signal.domain.enums.Tag
+
+data class FeedState(
+    val posts: List<PostsEntity.PostEntity>,
+    val tag: Tag,
+    val pageNum: Long,
+    val isPostsEmpty: Boolean,
+) {
+    companion object {
+        fun getDefaultState() = FeedState(
+            posts = listOf(),
+            tag = Tag.GENERAL,
+            pageNum = 1,
+            isPostsEmpty = false,
+        )
+    }
+}

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedViewModel.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedViewModel.kt
@@ -1,0 +1,51 @@
+package com.signal.signal_android.feature.main.feed
+
+import androidx.lifecycle.viewModelScope
+import com.signal.domain.PostsEntity
+import com.signal.domain.enums.Tag
+import com.signal.domain.repository.FeedRepository
+import com.signal.signal_android.BaseViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+internal class FeedViewModel(
+    private val feedRepository: FeedRepository,
+) : BaseViewModel<FeedState, FeedSideEffect>(FeedState.getDefaultState()) {
+    private val _posts: MutableList<PostsEntity.PostEntity> = mutableListOf()
+
+    init {
+        fetchPosts()
+    }
+
+    private fun fetchPosts() {
+        with(state.value) {
+            viewModelScope.launch(Dispatchers.IO) {
+                kotlin.runCatching {
+                    feedRepository.fetchPosts(
+                        tag = tag,
+                        pageNum = pageNum,
+                    )
+                }.onSuccess {
+                    _posts.addAll(it.postEntities)
+                    setState(copy(posts = _posts))
+                }.onFailure {
+                }
+            }
+        }
+    }
+
+    internal fun setTag() {
+        with(state.value) {
+            setState(
+                copy(
+                    tag = if (tag == Tag.GENERAL) {
+                        Tag.NOTIFICATION
+                    } else {
+                        Tag.GENERAL
+                    },
+                ),
+            )
+            fetchPosts()
+        }
+    }
+}

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedViewModel.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedViewModel.kt
@@ -48,6 +48,7 @@ internal class FeedViewModel(
                     title = title,
                     content = content,
                     image = image,
+                    tag = tag,
                 ).onSuccess {
                     postSideEffect(FeedSideEffect.PostSuccess)
                 }

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedViewModel.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedViewModel.kt
@@ -28,8 +28,15 @@ internal class FeedViewModel(
                     )
                 }.onSuccess {
                     _posts.addAll(it.postEntities)
-                    setState(copy(posts = _posts))
-                }.onFailure {}
+                    setState(
+                        copy(
+                            posts = _posts,
+                            isPostsEmpty = _posts.isEmpty(),
+                        )
+                    )
+                }.onFailure {
+                    setState(copy(isPostsEmpty = _posts.isEmpty()))
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedViewModel.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedViewModel.kt
@@ -41,10 +41,10 @@ internal class FeedViewModel(
         }
     }
 
-    internal fun post() {
+    internal fun createPost() {
         with(state.value) {
             viewModelScope.launch(Dispatchers.IO) {
-                feedRepository.post(
+                feedRepository.createPost(
                     title = title,
                     content = content,
                     image = image,

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedViewModel.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedViewModel.kt
@@ -2,6 +2,7 @@ package com.signal.signal_android.feature.main.feed
 
 import androidx.lifecycle.viewModelScope
 import com.signal.domain.PostsEntity
+import com.signal.domain.entity.PostDetailsEntity
 import com.signal.domain.enums.Tag
 import com.signal.domain.repository.FeedRepository
 import com.signal.signal_android.BaseViewModel
@@ -43,7 +44,27 @@ internal class FeedViewModel(
                 ).onSuccess {
                     postSideEffect(FeedSideEffect.PostSuccess)
                 }.onFailure {
+                }
+            }
+        }
+    }
 
+    internal fun fetchPostDetails() {
+        with(state.value) {
+            viewModelScope.launch(Dispatchers.IO) {
+                feedRepository.fetchPostDetails(feedId = feedId).onSuccess {
+                    setState(
+                        copy(
+                            postDetailsEntity = PostDetailsEntity(
+                                imageUrl = it.imageUrl,
+                                title = it.title,
+                                date = it.date,
+                                writer = it.writer,
+                                content = it.content,
+                                isMine = it.isMine,
+                            ),
+                        ),
+                    )
                 }
             }
         }
@@ -55,6 +76,10 @@ internal class FeedViewModel(
 
     internal fun setContent(content: String) {
         setState(state.value.copy(content = content))
+    }
+
+    internal fun setFeedId(feedId: Long) {
+        setState(state.value.copy(feedId = feedId))
     }
 
     internal fun setTag() {

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedViewModel.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedViewModel.kt
@@ -34,6 +34,29 @@ internal class FeedViewModel(
         }
     }
 
+    internal fun post() {
+        with(state.value) {
+            viewModelScope.launch(Dispatchers.IO) {
+                feedRepository.post(
+                    title = title,
+                    content = content,
+                ).onSuccess {
+                    postSideEffect(FeedSideEffect.PostSuccess)
+                }.onFailure {
+
+                }
+            }
+        }
+    }
+
+    internal fun setTitle(title: String) {
+        setState(state.value.copy(title = title))
+    }
+
+    internal fun setContent(content: String) {
+        setState(state.value.copy(content = content))
+    }
+
     internal fun setTag() {
         with(state.value) {
             setState(

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedViewModel.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedViewModel.kt
@@ -29,8 +29,7 @@ internal class FeedViewModel(
                 }.onSuccess {
                     _posts.addAll(it.postEntities)
                     setState(copy(posts = _posts))
-                }.onFailure {
-                }
+                }.onFailure {}
             }
         }
     }
@@ -43,7 +42,6 @@ internal class FeedViewModel(
                     content = content,
                 ).onSuccess {
                     postSideEffect(FeedSideEffect.PostSuccess)
-                }.onFailure {
                 }
             }
         }
@@ -61,6 +59,7 @@ internal class FeedViewModel(
                                 date = it.date,
                                 writer = it.writer,
                                 content = it.content,
+                                profile = it.profile,
                                 isMine = it.isMine,
                             ),
                         ),

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedViewModel.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/feed/FeedViewModel.kt
@@ -47,6 +47,7 @@ internal class FeedViewModel(
                 feedRepository.post(
                     title = title,
                     content = content,
+                    image = image,
                 ).onSuccess {
                     postSideEffect(FeedSideEffect.PostSuccess)
                 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -114,6 +114,8 @@
     <string name="feed_report">신고하기</string>
 
     <string name="feed_delete_dialog_title">정말 삭제하시겠습니까?</string>
+    <string name="feed_posts_is_empty">아직 게시글이 없어요!</string>
+    <string name="feed_posts_add">게시글 작성하기</string>
 
     <!--recommend-->
     <string name="recommend_search">추천 검색</string>


### PR DESCRIPTION
## 개요
> 커뮤니티 목록 및 작성 기능을 구현했습니다.

<img width="200" alt="스크린샷 2023-11-08 오후 2 17 06" src="https://github.com/Team-SIGNAL/SIGNAL-ANDROID/assets/102812085/c51aed69-a56d-4992-b735-86c6e0f25c16">


## 작업사항
- 목록 조회 비즈니스 로직 작성
- 게시글 작성 비즈니스 로직 작성
- 게시글 없는 경우 예외 처리

## 추가 로 할 말
- UseCase 없애고 runCatching 로직을 repository에서 처리해주도록 변경하였습니다.