### PR TITLE
🔀 :: (#79) 자가진단 최근 일자 기능 구현

### DIFF
--- a/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSource.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSource.kt
@@ -7,7 +7,10 @@ interface LocalDiagnosisDataSource {
 
     suspend fun setDiagnosis(diagnosisModel: DiagnosisModel)
 
-    fun saveLastDiagnosisDate(date: String)
+    fun saveLastDiagnosisDate(
+        date: String,
+        accountId: String,
+    )
 
     fun getLastDiagnosisDate(): String
 }

--- a/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSource.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSource.kt
@@ -8,4 +8,6 @@ interface LocalDiagnosisDataSource {
     suspend fun setDiagnosis(diagnosisModel: DiagnosisModel)
 
     fun saveLastDiagnosisDate(date: String)
+
+    fun getLastDiagnosisDate(): String
 }

--- a/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSource.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSource.kt
@@ -6,4 +6,6 @@ interface LocalDiagnosisDataSource {
     suspend fun getDiagnosis(): List<DiagnosisModel>
 
     suspend fun setDiagnosis(diagnosisModel: DiagnosisModel)
+
+    fun saveLastDiagnosisDate(date: String)
 }

--- a/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSourceImpl.kt
@@ -17,8 +17,13 @@ class LocalDiagnosisDataSourceImpl(
         diagnosisDao.setDiagnosis(diagnosisModel)
     }
 
-    override fun saveLastDiagnosisDate(date: String) {
-        preferenceManager.getSharedPreferenceEditor().putString(Keys.LAST_DIAGNOSIS_DATE, date).apply()
+    override fun saveLastDiagnosisDate(
+        date: String,
+        accountId: String,
+    ) {
+        preferenceManager.getSharedPreferenceEditor()
+            .putString(Keys.LAST_DIAGNOSIS_DATE + accountId, date)
+            .apply()
     }
 
     override fun getLastDiagnosisDate() =

--- a/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSourceImpl.kt
@@ -18,6 +18,9 @@ class LocalDiagnosisDataSourceImpl(
     }
 
     override fun saveLastDiagnosisDate(date: String) {
-        preferenceManager.getSharedPreferenceEditor().putString(Keys.LAST_DIAGNOSIS_DATE, date)
+        preferenceManager.getSharedPreferenceEditor().putString(Keys.LAST_DIAGNOSIS_DATE, date).apply()
     }
+
+    override fun getLastDiagnosisDate() =
+        preferenceManager.getSharedPreference().getString(Keys.LAST_DIAGNOSIS_DATE, "") ?: ""
 }

--- a/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSourceImpl.kt
@@ -26,6 +26,7 @@ class LocalDiagnosisDataSourceImpl(
             .apply()
     }
 
-    override fun getLastDiagnosisDate() =
-        preferenceManager.getSharedPreference().getString(Keys.LAST_DIAGNOSIS_DATE, "") ?: ""
+    override fun getLastDiagnosisDate(): String = with(preferenceManager.getSharedPreference()) {
+        return getString(Keys.LAST_DIAGNOSIS_DATE + getString(Keys.ACCOUNT_ID, ""), "") ?: ""
+    }
 }

--- a/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSourceImpl.kt
@@ -1,10 +1,13 @@
 package com.signal.data.datasource.diagnosis
 
 import com.signal.data.database.SignalDatabase
+import com.signal.data.datasource.user.local.Keys
 import com.signal.data.model.diagnosis.DiagnosisModel
+import com.signal.data.util.PreferenceManager
 
 class LocalDiagnosisDataSourceImpl(
-    private val database: SignalDatabase,
+    database: SignalDatabase,
+    private val preferenceManager: PreferenceManager,
 ) : LocalDiagnosisDataSource {
     private val diagnosisDao = database.getDiagnosisDao()
 
@@ -12,5 +15,9 @@ class LocalDiagnosisDataSourceImpl(
 
     override suspend fun setDiagnosis(diagnosisModel: DiagnosisModel) {
         diagnosisDao.setDiagnosis(diagnosisModel)
+    }
+
+    override fun saveLastDiagnosisDate(date: String) {
+        preferenceManager.getSharedPreferenceEditor().putString(Keys.LAST_DIAGNOSIS_DATE, date)
     }
 }

--- a/data/src/main/kotlin/com/signal/data/datasource/user/local/LocalUserDataSource.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/user/local/LocalUserDataSource.kt
@@ -11,7 +11,7 @@ interface LocalUserDataSource {
     fun getAccessToken(): String
     fun getRefreshToken(): String
     fun getExpireAt(): String
-    fun clearToken()
+    fun clearUserInformation()
 
     fun saveAccountId(email: String)
     fun getAccountId(): String

--- a/data/src/main/kotlin/com/signal/data/datasource/user/local/LocalUserDataSource.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/user/local/LocalUserDataSource.kt
@@ -12,4 +12,6 @@ interface LocalUserDataSource {
     fun getRefreshToken(): String
     fun getExpireAt(): String
     fun clearToken()
+
+    fun saveAccountId(email: String)
 }

--- a/data/src/main/kotlin/com/signal/data/datasource/user/local/LocalUserDataSource.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/user/local/LocalUserDataSource.kt
@@ -14,4 +14,5 @@ interface LocalUserDataSource {
     fun clearToken()
 
     fun saveAccountId(email: String)
+    fun getAccountId(): String
 }

--- a/data/src/main/kotlin/com/signal/data/datasource/user/local/LocalUserDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/user/local/LocalUserDataSourceImpl.kt
@@ -32,8 +32,14 @@ class LocalUserDataSourceImpl(
         return preferenceManager.getSharedPreference().getString(Keys.ACCESS_EXPIRED_AT, "") ?: ""
     }
 
-    override fun clearToken() {
-        preferenceManager.getSharedPreferenceEditor().clear().apply()
+    override fun clearUserInformation() {
+        preferenceManager.getSharedPreferenceEditor().apply {
+            putString(Keys.ACCESS_TOKEN, "")
+            putString(Keys.REFRESH_TOKEN, "")
+            putString(Keys.ACCESS_EXPIRED_AT, "")
+            putString(Keys.REFRESH_EXPIRED_AT, "")
+            putString(Keys.ACCOUNT_ID, "")
+        }.apply()
     }
 
     override fun saveAccountId(email: String) {

--- a/data/src/main/kotlin/com/signal/data/datasource/user/local/LocalUserDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/user/local/LocalUserDataSourceImpl.kt
@@ -35,6 +35,10 @@ class LocalUserDataSourceImpl(
     override fun clearToken() {
         preferenceManager.getSharedPreferenceEditor().clear().apply()
     }
+
+    override fun saveAccountId(email: String) {
+        preferenceManager.getSharedPreferenceEditor().putString(Keys.ACCOUNT_ID, email).apply()
+    }
 }
 
 object Keys {
@@ -44,4 +48,5 @@ object Keys {
     const val ACCESS_EXPIRED_AT = "access_expired_at"
     const val REFRESH_EXPIRED_AT = "refresh_expired_at"
     const val LAST_DIAGNOSIS_DATE = "last_diagnosis_date"
+    const val ACCOUNT_ID = "account_id"
 }

--- a/data/src/main/kotlin/com/signal/data/datasource/user/local/LocalUserDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/user/local/LocalUserDataSourceImpl.kt
@@ -1,18 +1,18 @@
 package com.signal.data.datasource.user.local
 
-import android.content.Context
-import android.content.SharedPreferences
+import com.signal.data.util.PreferenceManager
 
 class LocalUserDataSourceImpl(
-    private val context: Context,
+    private val preferenceManager: PreferenceManager,
 ) : LocalUserDataSource {
+
     override fun saveTokens(
         accessToken: String,
         refreshToken: String,
         accessExpiredAt: String,
         refreshExpiredAt: String,
     ) {
-        getSharedPreferenceEditor().also {
+        preferenceManager.getSharedPreferenceEditor().also {
             it.putString(Keys.ACCESS_TOKEN, accessToken)
             it.putString(Keys.REFRESH_TOKEN, refreshToken)
             it.putString(Keys.ACCESS_EXPIRED_AT, accessExpiredAt)
@@ -21,27 +21,19 @@ class LocalUserDataSourceImpl(
     }
 
     override fun getAccessToken(): String {
-        return getSharedPreference().getString(Keys.ACCESS_TOKEN, "") ?: ""
+        return preferenceManager.getSharedPreference().getString(Keys.ACCESS_TOKEN, "") ?: ""
     }
 
     override fun getRefreshToken(): String {
-        return getSharedPreference().getString(Keys.REFRESH_TOKEN, "") ?: ""
+        return preferenceManager.getSharedPreference().getString(Keys.REFRESH_TOKEN, "") ?: ""
     }
 
     override fun getExpireAt(): String {
-        return getSharedPreference().getString(Keys.ACCESS_EXPIRED_AT, "") ?: ""
+        return preferenceManager.getSharedPreference().getString(Keys.ACCESS_EXPIRED_AT, "") ?: ""
     }
 
     override fun clearToken() {
-        getSharedPreference().edit().clear().apply()
-    }
-
-    private fun getSharedPreference(): SharedPreferences {
-        return context.getSharedPreferences(Keys.NAME, Context.MODE_PRIVATE)
-    }
-
-    private fun getSharedPreferenceEditor(): SharedPreferences.Editor {
-        return getSharedPreference().edit()
+        preferenceManager.getSharedPreferenceEditor().clear().apply()
     }
 }
 
@@ -51,4 +43,5 @@ object Keys {
     const val REFRESH_TOKEN = "refresh_token"
     const val ACCESS_EXPIRED_AT = "access_expired_at"
     const val REFRESH_EXPIRED_AT = "refresh_expired_at"
+    const val LAST_DIAGNOSIS_DATE = "last_diagnosis_date"
 }

--- a/data/src/main/kotlin/com/signal/data/datasource/user/local/LocalUserDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/user/local/LocalUserDataSourceImpl.kt
@@ -34,11 +34,11 @@ class LocalUserDataSourceImpl(
 
     override fun clearUserInformation() {
         preferenceManager.getSharedPreferenceEditor().apply {
-            putString(Keys.ACCESS_TOKEN, "")
-            putString(Keys.REFRESH_TOKEN, "")
-            putString(Keys.ACCESS_EXPIRED_AT, "")
-            putString(Keys.REFRESH_EXPIRED_AT, "")
-            putString(Keys.ACCOUNT_ID, "")
+            remove(Keys.ACCESS_TOKEN)
+            remove(Keys.REFRESH_TOKEN)
+            remove(Keys.REFRESH_TOKEN)
+            remove(Keys.REFRESH_EXPIRED_AT)
+            remove(Keys.ACCOUNT_ID)
         }.apply()
     }
 

--- a/data/src/main/kotlin/com/signal/data/datasource/user/local/LocalUserDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/user/local/LocalUserDataSourceImpl.kt
@@ -39,6 +39,9 @@ class LocalUserDataSourceImpl(
     override fun saveAccountId(email: String) {
         preferenceManager.getSharedPreferenceEditor().putString(Keys.ACCOUNT_ID, email).apply()
     }
+
+    override fun getAccountId() =
+        preferenceManager.getSharedPreference().getString(Keys.ACCOUNT_ID, "") ?: ""
 }
 
 object Keys {

--- a/data/src/main/kotlin/com/signal/data/repository/DiagnosisRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/repository/DiagnosisRepositoryImpl.kt
@@ -16,4 +16,8 @@ class DiagnosisRepositoryImpl(
     override suspend fun setDiagnosis(diagnosisEntity: DiagnosisEntity) {
         localDiagnosisDataSource.setDiagnosis(diagnosisEntity.toModel())
     }
+
+    override fun saveLastDiagnosisDate(date: String) {
+        localDiagnosisDataSource.saveLastDiagnosisDate(date = date)
+    }
 }

--- a/data/src/main/kotlin/com/signal/data/repository/DiagnosisRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/repository/DiagnosisRepositoryImpl.kt
@@ -20,4 +20,8 @@ class DiagnosisRepositoryImpl(
     override fun saveLastDiagnosisDate(date: String) {
         localDiagnosisDataSource.saveLastDiagnosisDate(date = date)
     }
+
+    override fun getLastDiagnosisDate() = runCatching {
+        localDiagnosisDataSource.getLastDiagnosisDate()
+    }
 }

--- a/data/src/main/kotlin/com/signal/data/repository/DiagnosisRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/repository/DiagnosisRepositoryImpl.kt
@@ -17,8 +17,14 @@ class DiagnosisRepositoryImpl(
         localDiagnosisDataSource.setDiagnosis(diagnosisEntity.toModel())
     }
 
-    override fun saveLastDiagnosisDate(date: String) {
-        localDiagnosisDataSource.saveLastDiagnosisDate(date = date)
+    override fun saveLastDiagnosisDate(
+        date: String,
+        accountId: String,
+    ) {
+        localDiagnosisDataSource.saveLastDiagnosisDate(
+            date = date,
+            accountId = accountId,
+        )
     }
 
     override fun getLastDiagnosisDate() = runCatching {

--- a/data/src/main/kotlin/com/signal/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/repository/UserRepositoryImpl.kt
@@ -57,7 +57,7 @@ class UserRepositoryImpl(
     }
 
     override suspend fun signOut() {
-        localUserDataSource.clearToken()
+        localUserDataSource.clearUserInformation()
     }
 
     override suspend fun fetchUserInformation(): UserInformationEntity =

--- a/data/src/main/kotlin/com/signal/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/repository/UserRepositoryImpl.kt
@@ -62,4 +62,8 @@ class UserRepositoryImpl(
 
     override suspend fun fetchUserInformation(): UserInformationEntity =
         remoteUserDataSource.fetchUserInformation().toEntity()
+
+    override fun saveAccountId(email: String) {
+        localUserDataSource.saveAccountId(email = email)
+    }
 }

--- a/data/src/main/kotlin/com/signal/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/repository/UserRepositoryImpl.kt
@@ -66,4 +66,7 @@ class UserRepositoryImpl(
     override fun saveAccountId(email: String) {
         localUserDataSource.saveAccountId(email = email)
     }
+
+    override fun getAccountId() = localUserDataSource.getAccountId()
+
 }

--- a/data/src/main/kotlin/com/signal/data/util/PreferenceManager.kt
+++ b/data/src/main/kotlin/com/signal/data/util/PreferenceManager.kt
@@ -1,0 +1,17 @@
+package com.signal.data.util
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.signal.data.datasource.user.local.Keys
+
+class PreferenceManager(
+    private val context: Context,
+) {
+    internal fun getSharedPreference(): SharedPreferences {
+        return context.getSharedPreferences(Keys.NAME, Context.MODE_PRIVATE)
+    }
+
+    internal fun getSharedPreferenceEditor(): SharedPreferences.Editor {
+        return getSharedPreference().edit()
+    }
+}

--- a/domain/src/main/kotlin/com/signal/domain/repository/DiagnosisRepository.kt
+++ b/domain/src/main/kotlin/com/signal/domain/repository/DiagnosisRepository.kt
@@ -5,6 +5,10 @@ import com.signal.domain.entity.DiagnosisEntity
 interface DiagnosisRepository {
     suspend fun getDiagnosis(): Result<List<DiagnosisEntity>>
     suspend fun setDiagnosis(diagnosisEntity: DiagnosisEntity)
-    fun saveLastDiagnosisDate(date: String)
+    fun saveLastDiagnosisDate(
+        date: String,
+        accountId: String,
+    )
+
     fun getLastDiagnosisDate(): Result<String>
 }

--- a/domain/src/main/kotlin/com/signal/domain/repository/DiagnosisRepository.kt
+++ b/domain/src/main/kotlin/com/signal/domain/repository/DiagnosisRepository.kt
@@ -5,4 +5,5 @@ import com.signal.domain.entity.DiagnosisEntity
 interface DiagnosisRepository {
     suspend fun getDiagnosis(): Result<List<DiagnosisEntity>>
     suspend fun setDiagnosis(diagnosisEntity: DiagnosisEntity)
+    fun saveLastDiagnosisDate(date: String)
 }

--- a/domain/src/main/kotlin/com/signal/domain/repository/DiagnosisRepository.kt
+++ b/domain/src/main/kotlin/com/signal/domain/repository/DiagnosisRepository.kt
@@ -6,4 +6,5 @@ interface DiagnosisRepository {
     suspend fun getDiagnosis(): Result<List<DiagnosisEntity>>
     suspend fun setDiagnosis(diagnosisEntity: DiagnosisEntity)
     fun saveLastDiagnosisDate(date: String)
+    fun getLastDiagnosisDate(): Result<String>
 }

--- a/domain/src/main/kotlin/com/signal/domain/repository/UserRepository.kt
+++ b/domain/src/main/kotlin/com/signal/domain/repository/UserRepository.kt
@@ -22,4 +22,5 @@ interface UserRepository {
     suspend fun signOut()
     suspend fun fetchUserInformation(): UserInformationEntity
     fun saveAccountId(email: String)
+    fun getAccountId(): String
 }

--- a/domain/src/main/kotlin/com/signal/domain/repository/UserRepository.kt
+++ b/domain/src/main/kotlin/com/signal/domain/repository/UserRepository.kt
@@ -21,4 +21,5 @@ interface UserRepository {
     suspend fun secession()
     suspend fun signOut()
     suspend fun fetchUserInformation(): UserInformationEntity
+    fun saveAccountId(email: String)
 }

--- a/domain/src/main/kotlin/com/signal/domain/usecase/users/GetAccountIdUseCase.kt
+++ b/domain/src/main/kotlin/com/signal/domain/usecase/users/GetAccountIdUseCase.kt
@@ -1,0 +1,11 @@
+package com.signal.domain.usecase.users
+
+import com.signal.domain.repository.UserRepository
+
+class GetAccountIdUseCase(
+    private val userRepository: UserRepository,
+) {
+    operator fun invoke() = kotlin.runCatching {
+        userRepository.getAccountId()
+    }
+}

--- a/domain/src/main/kotlin/com/signal/domain/usecase/users/SaveAccountIdUseCase.kt
+++ b/domain/src/main/kotlin/com/signal/domain/usecase/users/SaveAccountIdUseCase.kt
@@ -1,0 +1,11 @@
+package com.signal.domain.usecase.users
+
+import com.signal.domain.repository.UserRepository
+
+class SaveAccountIdUseCase(
+    private val userRepository: UserRepository,
+) {
+    operator fun invoke(email: String) = kotlin.runCatching {
+        userRepository.saveAccountId(email)
+    }
+}

--- a/presentation/src/main/java/com/signal/signal_android/SignalApplication.kt
+++ b/presentation/src/main/java/com/signal/signal_android/SignalApplication.kt
@@ -8,29 +8,31 @@ import com.signal.data.datasource.diagnosis.LocalDiagnosisDataSource
 import com.signal.data.datasource.diagnosis.LocalDiagnosisDataSourceImpl
 import com.signal.data.datasource.feed.FeedDataSource
 import com.signal.data.datasource.feed.FeedDataSourceImpl
-import com.signal.data.datasource.file.AttachmentDataSourceImpl
 import com.signal.data.datasource.file.AttachmentDataSource
+import com.signal.data.datasource.file.AttachmentDataSourceImpl
 import com.signal.data.datasource.user.local.LocalUserDataSource
 import com.signal.data.datasource.user.local.LocalUserDataSourceImpl
 import com.signal.data.datasource.user.remote.RemoteUserDataSource
 import com.signal.data.datasource.user.remote.RemoteUserDataSourceImpl
+import com.signal.data.repository.AttachmentRepositoryImpl
 import com.signal.data.repository.DiagnosisRepositoryImpl
 import com.signal.data.repository.FeedRepositoryImpl
-import com.signal.data.repository.AttachmentRepositoryImpl
 import com.signal.data.repository.UserRepositoryImpl
+import com.signal.data.util.PreferenceManager
 import com.signal.data.util.TokenInterceptor
+import com.signal.domain.repository.AttachmentRepository
 import com.signal.domain.repository.DiagnosisRepository
 import com.signal.domain.repository.FeedRepository
-import com.signal.domain.repository.AttachmentRepository
 import com.signal.domain.repository.UserRepository
 import com.signal.domain.usecase.users.FetchUserInformationUseCase
 import com.signal.domain.usecase.users.SecessionUseCase
 import com.signal.domain.usecase.users.SignInUseCase
 import com.signal.domain.usecase.users.SignOutUseCase
 import com.signal.domain.usecase.users.SignUpUseCase
-import com.signal.signal_android.feature.file.AttachmentViewModel
 import com.signal.signal_android.feature.diagnosis.DiagnosisViewModel
+import com.signal.signal_android.feature.file.AttachmentViewModel
 import com.signal.signal_android.feature.main.feed.FeedViewModel
+import com.signal.signal_android.feature.main.home.HomeViewModel
 import com.signal.signal_android.feature.mypage.MyPageViewModel
 import com.signal.signal_android.feature.signin.SignInViewModel
 import com.signal.signal_android.feature.signup.SignUpViewModel
@@ -86,15 +88,23 @@ val daoModule: Module
                 database = get(),
             )
         }
+        single {
+            PreferenceManager(context = androidContext())
+        }
     }
 
 val dataSourceModule: Module
     get() = module {
         single<RemoteUserDataSource> { RemoteUserDataSourceImpl(userApi = get()) }
-        single<LocalUserDataSource> { LocalUserDataSourceImpl(context = androidContext()) }
+        single<LocalUserDataSource> { LocalUserDataSourceImpl(preferenceManager = get()) }
         single<FeedDataSource> { FeedDataSourceImpl(feedApi = get()) }
         single<AttachmentDataSource> { AttachmentDataSourceImpl(attachmentApi = get()) }
-        single<LocalDiagnosisDataSource> { LocalDiagnosisDataSourceImpl(database = get()) }
+        single<LocalDiagnosisDataSource> {
+            LocalDiagnosisDataSourceImpl(
+                database = get(),
+                preferenceManager = get(),
+            )
+        }
     }
 
 val repositoryModule: Module
@@ -138,4 +148,5 @@ val viewModelModule: Module
         viewModel { FeedViewModel(feedRepository = get()) }
         viewModel { AttachmentViewModel(attachmentRepository = get()) }
         viewModel { DiagnosisViewModel(diagnosisRepository = get()) }
+        viewModel { HomeViewModel(diagnosisRepository = get()) }
     }

--- a/presentation/src/main/java/com/signal/signal_android/SignalApplication.kt
+++ b/presentation/src/main/java/com/signal/signal_android/SignalApplication.kt
@@ -25,6 +25,7 @@ import com.signal.domain.repository.DiagnosisRepository
 import com.signal.domain.repository.FeedRepository
 import com.signal.domain.repository.UserRepository
 import com.signal.domain.usecase.users.FetchUserInformationUseCase
+import com.signal.domain.usecase.users.SaveAccountIdUseCase
 import com.signal.domain.usecase.users.SecessionUseCase
 import com.signal.domain.usecase.users.SignInUseCase
 import com.signal.domain.usecase.users.SignOutUseCase
@@ -132,11 +133,17 @@ val useCaseModule: Module
         single { SignOutUseCase(userRepository = get()) }
         single { SecessionUseCase(userRepository = get()) }
         single { FetchUserInformationUseCase(userRepository = get()) }
+        single { SaveAccountIdUseCase(userRepository = get()) }
     }
 
 val viewModelModule: Module
     get() = module {
-        viewModel { SignInViewModel(signInUseCase = get()) }
+        viewModel {
+            SignInViewModel(
+                signInUseCase = get(),
+                saveAccountIdUseCase = get(),
+            )
+        }
         viewModel { SignUpViewModel(signUpUseCase = get()) }
         viewModel {
             MyPageViewModel(

--- a/presentation/src/main/java/com/signal/signal_android/SignalApplication.kt
+++ b/presentation/src/main/java/com/signal/signal_android/SignalApplication.kt
@@ -25,6 +25,7 @@ import com.signal.domain.repository.DiagnosisRepository
 import com.signal.domain.repository.FeedRepository
 import com.signal.domain.repository.UserRepository
 import com.signal.domain.usecase.users.FetchUserInformationUseCase
+import com.signal.domain.usecase.users.GetAccountIdUseCase
 import com.signal.domain.usecase.users.SaveAccountIdUseCase
 import com.signal.domain.usecase.users.SecessionUseCase
 import com.signal.domain.usecase.users.SignInUseCase
@@ -134,6 +135,7 @@ val useCaseModule: Module
         single { SecessionUseCase(userRepository = get()) }
         single { FetchUserInformationUseCase(userRepository = get()) }
         single { SaveAccountIdUseCase(userRepository = get()) }
+        single { GetAccountIdUseCase(userRepository = get()) }
     }
 
 val viewModelModule: Module

--- a/presentation/src/main/java/com/signal/signal_android/SignalApplication.kt
+++ b/presentation/src/main/java/com/signal/signal_android/SignalApplication.kt
@@ -156,6 +156,11 @@ val viewModelModule: Module
         }
         viewModel { FeedViewModel(feedRepository = get()) }
         viewModel { AttachmentViewModel(attachmentRepository = get()) }
-        viewModel { DiagnosisViewModel(diagnosisRepository = get()) }
+        viewModel {
+            DiagnosisViewModel(
+                diagnosisRepository = get(),
+                getAccountIdUseCase = get(),
+            )
+        }
         viewModel { HomeViewModel(diagnosisRepository = get()) }
     }

--- a/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisComplete.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisComplete.kt
@@ -45,8 +45,8 @@ internal fun DiagnosisComplete(
         Buttons(
             onMainButtonClicked = {},
             onSubButtonClicked = {
-                moveToMain()
                 diagnosisViewModel.saveLastDiagnosisDate()
+                moveToMain()
             },
             mainText = stringResource(id = R.string.diagnosis_complete_check_result),
             subText = stringResource(id = R.string.diagnosis_complete_move_to_main),

--- a/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisComplete.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisComplete.kt
@@ -19,10 +19,12 @@ import com.signal.signal_android.designsystem.foundation.Body
 import com.signal.signal_android.designsystem.foundation.BodyStrong
 import com.signal.signal_android.designsystem.foundation.SignalColor
 import com.signal.signal_android.designsystem.foundation.Title
+import org.koin.androidx.compose.koinViewModel
 
 @Composable
 internal fun DiagnosisComplete(
     moveToMain: () -> Unit,
+    diagnosisViewModel: DiagnosisViewModel = koinViewModel(),
 ) {
     val requiredTime = "13분"
 
@@ -42,7 +44,10 @@ internal fun DiagnosisComplete(
         Spacer(modifier = Modifier.weight(1f))
         Buttons(
             onMainButtonClicked = {},
-            onSubButtonClicked = moveToMain,
+            onSubButtonClicked = {
+                moveToMain()
+                diagnosisViewModel.saveLastDiagnosisDate()
+            },
             mainText = stringResource(id = R.string.diagnosis_complete_check_result),
             subText = stringResource(id = R.string.diagnosis_complete_move_to_main),
         )

--- a/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisComplete.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisComplete.kt
@@ -9,13 +9,13 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.signal.signal_android.R
-import com.signal.signal_android.designsystem.foundation.Body
 import com.signal.signal_android.designsystem.foundation.BodyStrong
 import com.signal.signal_android.designsystem.foundation.SignalColor
 import com.signal.signal_android.designsystem.foundation.Title
@@ -26,28 +26,26 @@ internal fun DiagnosisComplete(
     moveToMain: () -> Unit,
     diagnosisViewModel: DiagnosisViewModel = koinViewModel(),
 ) {
-    val requiredTime = "13분"
+    LaunchedEffect(Unit){
+        diagnosisViewModel.saveLastDiagnosisDate()
+    }
 
     Column(
         modifier = Modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Spacer(modifier = Modifier.fillMaxHeight(0.3f))
-        // TODO: 이미지 변경
         Image(
             modifier = Modifier.size(132.dp),
-            painter = painterResource(id = R.drawable.ic_landing_diary),
-            contentDescription = stringResource(id = R.string.diagnosis_complete_image),
+            painter = painterResource(id = R.drawable.ic_pleased),
+            contentDescription = stringResource(id = R.string.emotion_pleased),
         )
         Spacer(modifier = Modifier.height(42.dp))
-        DiagnosisTexts(requiredTime = requiredTime)
+        DiagnosisTexts()
         Spacer(modifier = Modifier.weight(1f))
         Buttons(
             onMainButtonClicked = {},
-            onSubButtonClicked = {
-                diagnosisViewModel.saveLastDiagnosisDate()
-                moveToMain()
-            },
+            onSubButtonClicked = moveToMain,
             mainText = stringResource(id = R.string.diagnosis_complete_check_result),
             subText = stringResource(id = R.string.diagnosis_complete_move_to_main),
         )
@@ -55,7 +53,7 @@ internal fun DiagnosisComplete(
 }
 
 @Composable
-private fun DiagnosisTexts(requiredTime: String) {
+private fun DiagnosisTexts() {
     Title(
         modifier = Modifier.padding(bottom = 2.dp),
         text = stringResource(id = R.string.diagnosis_complete_title),
@@ -64,10 +62,5 @@ private fun DiagnosisTexts(requiredTime: String) {
         modifier = Modifier.padding(bottom = 2.dp),
         text = stringResource(id = R.string.diagnosis_description),
         color = SignalColor.Primary100,
-    )
-    Body(
-        modifier = Modifier.padding(bottom = 76.dp),
-        text = "걸린 시간 : $requiredTime",
-        color = SignalColor.Gray500,
     )
 }

--- a/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisState.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisState.kt
@@ -6,6 +6,7 @@ data class DiagnosisState(
     val size: Int,
     val diagnosis: List<DiagnosisEntity>,
     val count: Int,
+    val accountId: String,
 ) {
     companion object {
         fun getDefaultState() = DiagnosisState(
@@ -18,6 +19,7 @@ data class DiagnosisState(
                 ),
             ),
             count = 0,
+            accountId = "",
         )
     }
 }

--- a/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisViewModel.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisViewModel.kt
@@ -6,6 +6,8 @@ import com.signal.domain.repository.DiagnosisRepository
 import com.signal.signal_android.BaseViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 internal class DiagnosisViewModel(
     private val diagnosisRepository: DiagnosisRepository,
@@ -29,6 +31,14 @@ internal class DiagnosisViewModel(
                 )
             }.onFailure {
             }
+        }
+    }
+
+    internal fun saveLastDiagnosisDate() {
+        LocalDate.now().apply {
+            diagnosisRepository.saveLastDiagnosisDate(
+                "${year}년 ${monthValue}월 ${dayOfMonth}일"
+            )
         }
     }
 

--- a/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisViewModel.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisViewModel.kt
@@ -3,14 +3,15 @@ package com.signal.signal_android.feature.diagnosis
 import androidx.lifecycle.viewModelScope
 import com.signal.domain.entity.DiagnosisEntity
 import com.signal.domain.repository.DiagnosisRepository
+import com.signal.domain.usecase.users.GetAccountIdUseCase
 import com.signal.signal_android.BaseViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 internal class DiagnosisViewModel(
     private val diagnosisRepository: DiagnosisRepository,
+    private val getAccountIdUseCase: GetAccountIdUseCase,
 ) : BaseViewModel<DiagnosisState, DiagnosisSideEffect>(DiagnosisState.getDefaultState()) {
 
     private val diagnosis: MutableList<DiagnosisEntity> = mutableListOf()
@@ -35,10 +36,18 @@ internal class DiagnosisViewModel(
     }
 
     internal fun saveLastDiagnosisDate() {
+        getAccountId()
         LocalDate.now().apply {
             diagnosisRepository.saveLastDiagnosisDate(
-                "${year}년 ${monthValue}월 ${dayOfMonth}일"
+                date = "${year}년 ${monthValue}월 ${dayOfMonth}일",
+                accountId = state.value.accountId,
             )
+        }
+    }
+
+    private fun getAccountId() {
+        getAccountIdUseCase().onSuccess {
+            setState(state.value.copy(accountId = it))
         }
     }
 

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/home/Home.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/home/Home.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -36,12 +38,16 @@ import com.signal.signal_android.designsystem.foundation.BodyStrong
 import com.signal.signal_android.designsystem.foundation.SignalColor
 import com.signal.signal_android.designsystem.foundation.SubTitle
 import com.signal.signal_android.designsystem.util.signalClickable
+import org.koin.androidx.compose.koinViewModel
 
 @Composable
 internal fun Home(
     moveToReservation: () -> Unit,
     moveToDiagnosisLanding: () -> Unit,
+    homeViewModel: HomeViewModel = koinViewModel(),
 ) {
+    val state by homeViewModel.state.collectAsState()
+
     Column {
         Column(modifier = Modifier.padding(horizontal = 16.dp)) {
             Spacer(modifier = Modifier.height(30.dp))
@@ -85,11 +91,17 @@ internal fun Home(
             Spacer(modifier = Modifier.height(12.dp))
             BodyLarge2(text = stringResource(id = R.string.home_activity))
             Spacer(modifier = Modifier.height(8.dp))
-            ActivityCard(
-                title = stringResource(id = R.string.diagnosis_title),
-                description = "최근 진행 : 2023년 10월 21일",
-                onClick = moveToDiagnosisLanding,
-            )
+            state.lastDiagnosisDate.run {
+                ActivityCard(
+                    title = stringResource(id = R.string.diagnosis_title),
+                    description = if (this.isBlank()) {
+                        null
+                    } else {
+                        "최근 진행 : ${state.lastDiagnosisDate}"
+                    },
+                    onClick = moveToDiagnosisLanding,
+                )
+            }
             Spacer(modifier = Modifier.height(14.dp))
             ReservationCard(
                 title = stringResource(id = R.string.reservation),
@@ -227,7 +239,6 @@ private fun ReservationCard(
         }
     }
 }
-
 
 @Composable
 private fun ActivityCard(

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/home/HomeSideEffect.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/home/HomeSideEffect.kt
@@ -1,0 +1,3 @@
+package com.signal.signal_android.feature.main.home
+
+sealed interface HomeSideEffect

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/home/HomeState.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/home/HomeState.kt
@@ -1,0 +1,11 @@
+package com.signal.signal_android.feature.main.home
+
+data class HomeState(
+    val lastDiagnosisDate: String,
+) {
+    companion object {
+        fun getDefaultState() = HomeState(
+            lastDiagnosisDate = "",
+        )
+    }
+}

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/home/HomeViewModel.kt
@@ -1,0 +1,22 @@
+package com.signal.signal_android.feature.main.home
+
+import android.util.Log
+import com.signal.domain.repository.DiagnosisRepository
+import com.signal.signal_android.BaseViewModel
+
+internal class HomeViewModel(
+    private val diagnosisRepository: DiagnosisRepository,
+) : BaseViewModel<HomeState, HomeSideEffect>(HomeState.getDefaultState()) {
+    init {
+        getLastDiagnosisDate()
+    }
+
+    private fun getLastDiagnosisDate() {
+        diagnosisRepository.getLastDiagnosisDate().onSuccess {
+            Log.d("TEST", it)
+            setState(state.value.copy(lastDiagnosisDate = it))
+        }.onFailure {
+            Log.d("TEST", it.toString())
+        }
+    }
+}

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/home/HomeViewModel.kt
@@ -1,6 +1,5 @@
 package com.signal.signal_android.feature.main.home
 
-import android.util.Log
 import com.signal.domain.repository.DiagnosisRepository
 import com.signal.signal_android.BaseViewModel
 
@@ -13,10 +12,7 @@ internal class HomeViewModel(
 
     private fun getLastDiagnosisDate() {
         diagnosisRepository.getLastDiagnosisDate().onSuccess {
-            Log.d("TEST", it)
             setState(state.value.copy(lastDiagnosisDate = it))
-        }.onFailure {
-            Log.d("TEST", it.toString())
-        }
+        }.onFailure { }
     }
 }

--- a/presentation/src/main/java/com/signal/signal_android/feature/signin/SignInViewModel.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/signin/SignInViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.signal.domain.exception.NotFoundException
 import com.signal.domain.exception.OfflineException
 import com.signal.domain.exception.UnAuthorizationException
+import com.signal.domain.usecase.users.SaveAccountIdUseCase
 import com.signal.domain.usecase.users.SignInUseCase
 import com.signal.signal_android.BaseViewModel
 import kotlinx.coroutines.Dispatchers
@@ -11,6 +12,7 @@ import kotlinx.coroutines.launch
 
 class SignInViewModel(
     private val signInUseCase: SignInUseCase,
+    private val saveAccountIdUseCase: SaveAccountIdUseCase,
 ) : BaseViewModel<SignInState, SignInSideEffect>(SignInState.getDefaultState()) {
 
     internal fun setAccountId(accountId: String) {
@@ -51,6 +53,7 @@ class SignInViewModel(
                 accountId = state.value.accountId,
                 password = state.value.password,
             ).onSuccess {
+                saveAccountId()
                 postSideEffect(SignInSideEffect.Success)
             }.onFailure {
                 when (it) {
@@ -61,5 +64,9 @@ class SignInViewModel(
                 }
             }
         }
+    }
+
+    private fun saveAccountId(){
+        saveAccountIdUseCase(email = state.value.accountId)
     }
 }


### PR DESCRIPTION
## 개요
> 유저 아이디로 최근 자가진단 일자를 저장하고 불러오는 로직을 구현했습니다.

<img width="328" alt="스크린샷 2023-11-13 오전 9 40 07" src="https://github.com/Team-SIGNAL/SIGNAL-ANDROID/assets/102812085/aa0f3035-1223-47cd-b2b2-7175e1f2e6f8">

<img width="333" alt="스크린샷 2023-11-13 오전 10 36 17" src="https://github.com/Team-SIGNAL/SIGNAL-ANDROID/assets/102812085/4d8b07aa-64f6-4023-b83c-3292e256d5a0">



## 작업사항
- 유저 정보 초기화 리팩토링
- 날짜 저장 및 유저 아이디 저장 로직 구현
- 날짜 불러오기 및 유저 아이디 불러오기 로직 구현

## 추가 로 할 말
