### PR TITLE
🔀 :: (#96) 우울증 수치 차트 연동

### DIFF
--- a/data/src/main/kotlin/com/signal/data/dao/DiagnosisDao.kt
+++ b/data/src/main/kotlin/com/signal/data/dao/DiagnosisDao.kt
@@ -12,8 +12,8 @@ interface DiagnosisDao {
     @Query("select * from diagnosis")
     fun getDiagnosis(): List<DiagnosisModel>
 
-    @Query("select * from diagnosisHistory")
-    fun getDiagnosisHistories(): List<DiagnosisHistoryModel>
+    @Query("select * from diagnosisHistory where userId = :userId")
+    fun getDiagnosisHistories(userId: String): List<DiagnosisHistoryModel>
 
     @Update
     fun setDiagnosis(diagnosisModel: DiagnosisModel)

--- a/data/src/main/kotlin/com/signal/data/dao/DiagnosisDao.kt
+++ b/data/src/main/kotlin/com/signal/data/dao/DiagnosisDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Update
+import com.signal.data.model.diagnosis.DiagnosisHistoryModel
 import com.signal.data.model.diagnosis.DiagnosisModel
 
 @Dao
@@ -11,9 +12,18 @@ interface DiagnosisDao {
     @Query("select * from diagnosis")
     fun getDiagnosis(): List<DiagnosisModel>
 
+    @Query("select * from diagnosisHistory")
+    fun getDiagnosisHistories(): List<DiagnosisHistoryModel>
+
     @Update
     fun setDiagnosis(diagnosisModel: DiagnosisModel)
 
+    @Update
+    fun setDiagnosisHistory(diagnosisHistory: DiagnosisHistoryModel)
+
     @Insert
     fun addDiagnosis(diagnosis: List<DiagnosisModel>)
+
+    @Insert
+    fun addDiagnosisHistory(diagnosisHistory: DiagnosisHistoryModel)
 }

--- a/data/src/main/kotlin/com/signal/data/database/SignalDatabase.kt
+++ b/data/src/main/kotlin/com/signal/data/database/SignalDatabase.kt
@@ -3,10 +3,11 @@ package com.signal.data.database
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import com.signal.data.dao.DiagnosisDao
+import com.signal.data.model.diagnosis.DiagnosisHistoryModel
 import com.signal.data.model.diagnosis.DiagnosisModel
 
 @Database(
-    entities = [DiagnosisModel::class],
+    entities = [DiagnosisModel::class, DiagnosisHistoryModel::class],
     version = 1,
 )
 abstract class SignalDatabase : RoomDatabase() {

--- a/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSource.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSource.kt
@@ -1,11 +1,16 @@
 package com.signal.data.datasource.diagnosis
 
+import com.signal.data.model.diagnosis.DiagnosisHistoryModel
 import com.signal.data.model.diagnosis.DiagnosisModel
 
 interface LocalDiagnosisDataSource {
     suspend fun getDiagnosis(): List<DiagnosisModel>
 
+    suspend fun getDiagnosisHistories(): List<DiagnosisHistoryModel>
+
     suspend fun setDiagnosis(diagnosisModel: DiagnosisModel)
+
+    suspend fun setDiagnosisHistory(diagnosisHistoryModel: DiagnosisHistoryModel)
 
     fun saveLastDiagnosisDate(
         date: String,
@@ -13,4 +18,6 @@ interface LocalDiagnosisDataSource {
     )
 
     fun getLastDiagnosisDate(): String
+
+    fun addDiagnosisHistory(diagnosisHistoryModel: DiagnosisHistoryModel)
 }

--- a/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSource.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSource.kt
@@ -6,7 +6,7 @@ import com.signal.data.model.diagnosis.DiagnosisModel
 interface LocalDiagnosisDataSource {
     suspend fun getDiagnosis(): List<DiagnosisModel>
 
-    suspend fun getDiagnosisHistories(): List<DiagnosisHistoryModel>
+    suspend fun getDiagnosisHistories(userId: String): List<DiagnosisHistoryModel>
 
     suspend fun setDiagnosis(diagnosisModel: DiagnosisModel)
 

--- a/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSourceImpl.kt
@@ -14,7 +14,8 @@ class LocalDiagnosisDataSourceImpl(
 
     override suspend fun getDiagnosis() = diagnosisDao.getDiagnosis()
 
-    override suspend fun getDiagnosisHistories() = diagnosisDao.getDiagnosisHistories()
+    override suspend fun getDiagnosisHistories(userId: String) =
+        diagnosisDao.getDiagnosisHistories(userId = userId)
 
     override suspend fun setDiagnosis(diagnosisModel: DiagnosisModel) {
         diagnosisDao.setDiagnosis(diagnosisModel)

--- a/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/datasource/diagnosis/LocalDiagnosisDataSourceImpl.kt
@@ -2,6 +2,7 @@ package com.signal.data.datasource.diagnosis
 
 import com.signal.data.database.SignalDatabase
 import com.signal.data.datasource.user.local.Keys
+import com.signal.data.model.diagnosis.DiagnosisHistoryModel
 import com.signal.data.model.diagnosis.DiagnosisModel
 import com.signal.data.util.PreferenceManager
 
@@ -13,8 +14,14 @@ class LocalDiagnosisDataSourceImpl(
 
     override suspend fun getDiagnosis() = diagnosisDao.getDiagnosis()
 
+    override suspend fun getDiagnosisHistories() = diagnosisDao.getDiagnosisHistories()
+
     override suspend fun setDiagnosis(diagnosisModel: DiagnosisModel) {
         diagnosisDao.setDiagnosis(diagnosisModel)
+    }
+
+    override suspend fun setDiagnosisHistory(diagnosisHistoryModel: DiagnosisHistoryModel) {
+        diagnosisDao.setDiagnosisHistory(diagnosisHistoryModel)
     }
 
     override fun saveLastDiagnosisDate(
@@ -28,5 +35,9 @@ class LocalDiagnosisDataSourceImpl(
 
     override fun getLastDiagnosisDate(): String = with(preferenceManager.getSharedPreference()) {
         return getString(Keys.LAST_DIAGNOSIS_DATE + getString(Keys.ACCOUNT_ID, ""), "") ?: ""
+    }
+
+    override fun addDiagnosisHistory(diagnosisHistoryModel: DiagnosisHistoryModel) {
+        diagnosisDao.addDiagnosisHistory(diagnosisHistoryModel)
     }
 }

--- a/data/src/main/kotlin/com/signal/data/model/diagnosis/DiagnosisHistoryModel.kt
+++ b/data/src/main/kotlin/com/signal/data/model/diagnosis/DiagnosisHistoryModel.kt
@@ -1,0 +1,29 @@
+package com.signal.data.model.diagnosis
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.signal.domain.entity.DiagnosisHistoryEntity
+import java.time.LocalDate
+import java.util.UUID
+
+@Entity("diagnosisHistory")
+data class DiagnosisHistoryModel(
+    @PrimaryKey val id: Long,
+    val score: Long,
+    val userId: String,
+    val date: String,
+)
+
+fun DiagnosisHistoryModel.toEntity() = DiagnosisHistoryEntity(
+    id = this.id,
+    score = this.score,
+    userId = this.userId,
+    date = this.date,
+)
+
+fun DiagnosisHistoryEntity.toModel() = DiagnosisHistoryModel(
+    id = this.id,
+    score = this.score,
+    userId = this.userId,
+    date = this.date,
+)

--- a/data/src/main/kotlin/com/signal/data/repository/DiagnosisRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/repository/DiagnosisRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.signal.data.datasource.diagnosis.LocalDiagnosisDataSource
 import com.signal.data.model.diagnosis.toEntity
 import com.signal.data.model.diagnosis.toModel
 import com.signal.domain.entity.DiagnosisEntity
+import com.signal.domain.entity.DiagnosisHistoryEntity
 import com.signal.domain.repository.DiagnosisRepository
 
 class DiagnosisRepositoryImpl(
@@ -29,5 +30,17 @@ class DiagnosisRepositoryImpl(
 
     override fun getLastDiagnosisDate() = runCatching {
         localDiagnosisDataSource.getLastDiagnosisDate()
+    }
+
+    override suspend fun getDiagnosisHistories() = kotlin.runCatching {
+        localDiagnosisDataSource.getDiagnosisHistories().map { it.toEntity() }
+    }
+
+    override suspend fun setDiagnosisHistory(diagnosisHistoryEntity: DiagnosisHistoryEntity) {
+        localDiagnosisDataSource.setDiagnosisHistory(diagnosisHistoryEntity.toModel())
+    }
+
+    override suspend fun addDiagnosisHistory(diagnosisHistoryEntity: DiagnosisHistoryEntity) {
+        localDiagnosisDataSource.addDiagnosisHistory(diagnosisHistoryEntity.toModel())
     }
 }

--- a/data/src/main/kotlin/com/signal/data/repository/DiagnosisRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/signal/data/repository/DiagnosisRepositoryImpl.kt
@@ -32,9 +32,9 @@ class DiagnosisRepositoryImpl(
         localDiagnosisDataSource.getLastDiagnosisDate()
     }
 
-    override suspend fun getDiagnosisHistories() = kotlin.runCatching {
-        localDiagnosisDataSource.getDiagnosisHistories().map { it.toEntity() }
-    }
+    override suspend fun getDiagnosisHistories(userId: String) =
+        localDiagnosisDataSource.getDiagnosisHistories(userId = userId).map { it.toEntity() }
+
 
     override suspend fun setDiagnosisHistory(diagnosisHistoryEntity: DiagnosisHistoryEntity) {
         localDiagnosisDataSource.setDiagnosisHistory(diagnosisHistoryEntity.toModel())

--- a/domain/src/main/kotlin/com/signal/domain/entity/DiagnosisHistoryEntity.kt
+++ b/domain/src/main/kotlin/com/signal/domain/entity/DiagnosisHistoryEntity.kt
@@ -1,0 +1,8 @@
+package com.signal.domain.entity
+
+data class DiagnosisHistoryEntity(
+    val id: Long,
+    val score: Long,
+    val userId: String,
+    val date: String,
+)

--- a/domain/src/main/kotlin/com/signal/domain/enums/ChartViewType.kt
+++ b/domain/src/main/kotlin/com/signal/domain/enums/ChartViewType.kt
@@ -1,0 +1,8 @@
+package com.signal.domain.enums
+
+enum class ChartViewType(val value: String) {
+    DAY("일별"),
+    WEEK("주별"),
+    MONTH("월별"),
+    YEAR("연도별"),
+}

--- a/domain/src/main/kotlin/com/signal/domain/repository/DiagnosisRepository.kt
+++ b/domain/src/main/kotlin/com/signal/domain/repository/DiagnosisRepository.kt
@@ -13,7 +13,7 @@ interface DiagnosisRepository {
 
     fun getLastDiagnosisDate(): Result<String>
 
-    suspend fun getDiagnosisHistories(): Result<List<DiagnosisHistoryEntity>>
+    suspend fun getDiagnosisHistories(userId: String): List<DiagnosisHistoryEntity>
 
     suspend fun setDiagnosisHistory(diagnosisHistoryEntity: DiagnosisHistoryEntity)
 

--- a/domain/src/main/kotlin/com/signal/domain/repository/DiagnosisRepository.kt
+++ b/domain/src/main/kotlin/com/signal/domain/repository/DiagnosisRepository.kt
@@ -1,6 +1,7 @@
 package com.signal.domain.repository
 
 import com.signal.domain.entity.DiagnosisEntity
+import com.signal.domain.entity.DiagnosisHistoryEntity
 
 interface DiagnosisRepository {
     suspend fun getDiagnosis(): Result<List<DiagnosisEntity>>
@@ -11,4 +12,10 @@ interface DiagnosisRepository {
     )
 
     fun getLastDiagnosisDate(): Result<String>
+
+    suspend fun getDiagnosisHistories(): Result<List<DiagnosisHistoryEntity>>
+
+    suspend fun setDiagnosisHistory(diagnosisHistoryEntity: DiagnosisHistoryEntity)
+
+    suspend fun addDiagnosisHistory(diagnosisHistoryEntity: DiagnosisHistoryEntity)
 }

--- a/domain/src/main/kotlin/com/signal/domain/usecase/users/GetDiagnosisHistoriesUseCase.kt
+++ b/domain/src/main/kotlin/com/signal/domain/usecase/users/GetDiagnosisHistoriesUseCase.kt
@@ -1,0 +1,11 @@
+package com.signal.domain.usecase.users
+
+import com.signal.domain.repository.DiagnosisRepository
+
+class GetDiagnosisHistoriesUseCase(
+    private val diagnosisRepository: DiagnosisRepository,
+) {
+    suspend operator fun invoke(userId: String) = kotlin.runCatching {
+        diagnosisRepository.getDiagnosisHistories(userId = userId)
+    }
+}

--- a/presentation/src/main/java/com/signal/signal_android/SignalApplication.kt
+++ b/presentation/src/main/java/com/signal/signal_android/SignalApplication.kt
@@ -178,7 +178,6 @@ val viewModelModule: Module
         }
         viewModel {
             HomeViewModel(
-                diagnosisRepository = get(),
                 getDiagnosisHistoriesUseCase = get(),
                 getAccountIdUseCase = get(),
             )

--- a/presentation/src/main/java/com/signal/signal_android/SignalApplication.kt
+++ b/presentation/src/main/java/com/signal/signal_android/SignalApplication.kt
@@ -30,6 +30,7 @@ import com.signal.domain.repository.FeedRepository
 import com.signal.domain.repository.UserRepository
 import com.signal.domain.usecase.users.FetchUserInformationUseCase
 import com.signal.domain.usecase.users.GetAccountIdUseCase
+import com.signal.domain.usecase.users.GetDiagnosisHistoriesUseCase
 import com.signal.domain.usecase.users.SaveAccountIdUseCase
 import com.signal.domain.usecase.users.SecessionUseCase
 import com.signal.domain.usecase.users.SignInUseCase
@@ -147,6 +148,7 @@ val useCaseModule: Module
         single { FetchUserInformationUseCase(userRepository = get()) }
         single { SaveAccountIdUseCase(userRepository = get()) }
         single { GetAccountIdUseCase(userRepository = get()) }
+        single { GetDiagnosisHistoriesUseCase(diagnosisRepository = get()) }
     }
 
 val viewModelModule: Module
@@ -171,8 +173,15 @@ val viewModelModule: Module
             DiagnosisViewModel(
                 diagnosisRepository = get(),
                 getAccountIdUseCase = get(),
+                getDiagnosisHistoriesUseCase = get(),
             )
         }
-        viewModel { HomeViewModel(diagnosisRepository = get()) }
+        viewModel {
+            HomeViewModel(
+                diagnosisRepository = get(),
+                getDiagnosisHistoriesUseCase = get(),
+                getAccountIdUseCase = get(),
+            )
+        }
         viewModel { DiaryViewModel(diaryRepository = get()) }
     }

--- a/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/Diagnosis.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/Diagnosis.kt
@@ -54,7 +54,7 @@ internal fun Diagnosis(
 
     var showDialog by remember { mutableStateOf(false) }
 
-    if(showDialog) {
+    if (showDialog) {
         Dialog(onDismissRequest = { showDialog = false }) {
             SignalDialog(
                 title = stringResource(id = R.string.diagnosis_exit),

--- a/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisComplete.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisComplete.kt
@@ -26,8 +26,11 @@ internal fun DiagnosisComplete(
     moveToMain: () -> Unit,
     diagnosisViewModel: DiagnosisViewModel = koinViewModel(),
 ) {
-    LaunchedEffect(Unit){
-        diagnosisViewModel.saveLastDiagnosisDate()
+    LaunchedEffect(Unit) {
+        with(diagnosisViewModel) {
+            saveLastDiagnosisDate()
+            addDiagnosisHistory()
+        }
     }
 
     Column(

--- a/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisComplete.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisComplete.kt
@@ -27,10 +27,7 @@ internal fun DiagnosisComplete(
     diagnosisViewModel: DiagnosisViewModel = koinViewModel(),
 ) {
     LaunchedEffect(Unit) {
-        with(diagnosisViewModel) {
-            saveLastDiagnosisDate()
-            addDiagnosisHistory()
-        }
+        diagnosisViewModel.addDiagnosisHistory()
     }
 
     Column(

--- a/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisState.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisState.kt
@@ -15,8 +15,8 @@ data class DiagnosisState(
                 DiagnosisEntity(
                     id = 0L,
                     question = "",
-                    score = 0L,
-                ),
+                    score = null,
+                )
             ),
             count = 0,
             accountId = "",

--- a/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisViewModel.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisViewModel.kt
@@ -5,6 +5,7 @@ import com.signal.domain.entity.DiagnosisEntity
 import com.signal.domain.entity.DiagnosisHistoryEntity
 import com.signal.domain.repository.DiagnosisRepository
 import com.signal.domain.usecase.users.GetAccountIdUseCase
+import com.signal.domain.usecase.users.GetDiagnosisHistoriesUseCase
 import com.signal.signal_android.BaseViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -13,6 +14,7 @@ import java.time.LocalDate
 internal class DiagnosisViewModel(
     private val diagnosisRepository: DiagnosisRepository,
     private val getAccountIdUseCase: GetAccountIdUseCase,
+    private val getDiagnosisHistoriesUseCase: GetDiagnosisHistoriesUseCase,
 ) : BaseViewModel<DiagnosisState, DiagnosisSideEffect>(DiagnosisState.getDefaultState()) {
 
     private val diagnosis: MutableList<DiagnosisEntity> = mutableListOf()
@@ -25,7 +27,7 @@ internal class DiagnosisViewModel(
 
     private fun getDiagnosisHistories() {
         viewModelScope.launch(Dispatchers.IO) {
-            diagnosisRepository.getDiagnosisHistories().onSuccess {
+            getDiagnosisHistoriesUseCase(userId = state.value.accountId).onSuccess {
                 diagnosisHistories.addAll(it)
             }
         }

--- a/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisViewModel.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisViewModel.kt
@@ -22,6 +22,7 @@ internal class DiagnosisViewModel(
 
     init {
         getDiagnosis()
+        getAccountId()
         getDiagnosisHistories()
     }
 
@@ -44,16 +45,6 @@ internal class DiagnosisViewModel(
                     ),
                 )
             }
-        }
-    }
-
-    internal fun saveLastDiagnosisDate() {
-        getAccountId()
-        LocalDate.now().apply {
-            diagnosisRepository.saveLastDiagnosisDate(
-                date = "${year}년 ${monthValue}월 ${dayOfMonth}일",
-                accountId = state.value.accountId,
-            )
         }
     }
 
@@ -84,8 +75,8 @@ internal class DiagnosisViewModel(
                 if (diagnosisHistories.none { it.date == date }) {
                     diagnosisRepository.addDiagnosisHistory(
                         DiagnosisHistoryEntity(
-                            id = if (diagnosisHistories.isEmpty()) 0L
-                            else diagnosisHistories.last().id + 1L,
+                            id = if (diagnosisHistories.isEmpty()) 0
+                            else diagnosisHistories.last().id + 1,
                             score = score,
                             userId = accountId,
                             date = date,

--- a/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisViewModel.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/diagnosis/DiagnosisViewModel.kt
@@ -20,7 +20,7 @@ internal class DiagnosisViewModel(
 
     init {
         getDiagnosis()
-        //getDiagnosisHistories()
+        getDiagnosisHistories()
     }
 
     private fun getDiagnosisHistories() {
@@ -77,17 +77,25 @@ internal class DiagnosisViewModel(
     internal fun addDiagnosisHistory() {
         with(state.value) {
             viewModelScope.launch(Dispatchers.IO) {
-                diagnosisRepository.addDiagnosisHistory(
-                    DiagnosisHistoryEntity(
-                        id = if (diagnosis.isEmpty()) 0L
-                        else diagnosis.last().id + 1L,
-                        score = diagnosis.sumOf {
-                            it.score ?: 0L
-                        },
-                        userId = accountId,
-                        date = LocalDate.now().toString(),
+                val date = LocalDate.now().toString()
+                val score = diagnosis.sumOf { it.score ?: 0L }
+                if (diagnosisHistories.none { it.date == date }) {
+                    diagnosisRepository.addDiagnosisHistory(
+                        DiagnosisHistoryEntity(
+                            id = if (diagnosisHistories.isEmpty()) 0L
+                            else diagnosisHistories.last().id + 1L,
+                            score = score,
+                            userId = accountId,
+                            date = date,
+                        )
                     )
-                )
+                } else {
+                    diagnosisRepository.setDiagnosisHistory(
+                        diagnosisHistories.first { it.date == date }.copy(
+                            score = score,
+                        )
+                    )
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/home/Home.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/home/Home.kt
@@ -71,9 +71,9 @@ internal fun Home(
             }
             Spacer(modifier = Modifier.height(34.dp))
             HomeChart(
-                onNext = {},
-                currentView = "월별",
-                onPrevious = {},
+                onNext = homeViewModel::nextChartViewType,
+                currentView = state.chartViewType.value,
+                onPrevious = homeViewModel::previousChartViewType,
             )
             Spacer(modifier = Modifier.height(34.dp))
         }

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/home/Home.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/home/Home.kt
@@ -29,8 +29,10 @@ import coil.compose.AsyncImage
 import com.patrykandpatrick.vico.compose.axis.horizontal.rememberBottomAxis
 import com.patrykandpatrick.vico.compose.axis.vertical.rememberStartAxis
 import com.patrykandpatrick.vico.compose.chart.Chart
+import com.patrykandpatrick.vico.core.entry.FloatEntry
 import com.patrykandpatrick.vico.core.entry.entryModelOf
 import com.patrykandpatrick.vico.views.chart.line.lineChart
+import com.signal.domain.entity.DiagnosisHistoryEntity
 import com.signal.signal_android.R
 import com.signal.signal_android.designsystem.foundation.Body
 import com.signal.signal_android.designsystem.foundation.BodyLarge2
@@ -74,6 +76,7 @@ internal fun Home(
                 onNext = homeViewModel::nextChartViewType,
                 currentView = state.chartViewType.value,
                 onPrevious = homeViewModel::previousChartViewType,
+                diagnosisHistories = state.diagnosisHistories,
             )
             Spacer(modifier = Modifier.height(34.dp))
         }
@@ -150,11 +153,11 @@ private fun OngoingActivity(
 
 @Composable
 private fun HomeChart(
+    diagnosisHistories: List<DiagnosisHistoryEntity>,
     onPrevious: () -> Unit,
     onNext: () -> Unit,
     currentView: String,
 ) {
-    val chartEntryModel = entryModelOf(1, 2, 3, 4, 5, 6, 7)
     val context = LocalContext.current
 
     Row(
@@ -191,11 +194,14 @@ private fun HomeChart(
     Spacer(modifier = Modifier.height(8.dp))
     Chart(
         chart = lineChart(context = context),
-        model = chartEntryModel,
+        model = diagnosisHistories.toChartModel(),
         startAxis = rememberStartAxis(),
         bottomAxis = rememberBottomAxis(),
     )
 }
+
+private fun List<DiagnosisHistoryEntity>.toChartModel() =
+    entryModelOf(this.map { FloatEntry(it.date.toFloat(), it.score.toFloat()) })
 
 @Composable
 private fun ReservationCard(

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/home/HomeState.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/home/HomeState.kt
@@ -1,11 +1,15 @@
 package com.signal.signal_android.feature.main.home
 
+import com.signal.domain.enums.ChartViewType
+
 data class HomeState(
     val lastDiagnosisDate: String,
+    val chartViewType: ChartViewType,
 ) {
     companion object {
         fun getDefaultState() = HomeState(
             lastDiagnosisDate = "",
+            chartViewType = ChartViewType.DAY,
         )
     }
 }

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/home/HomeState.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/home/HomeState.kt
@@ -1,15 +1,18 @@
 package com.signal.signal_android.feature.main.home
 
+import com.signal.domain.entity.DiagnosisHistoryEntity
 import com.signal.domain.enums.ChartViewType
 
 data class HomeState(
     val lastDiagnosisDate: String,
     val chartViewType: ChartViewType,
+    val diagnosisHistories: List<DiagnosisHistoryEntity>,
 ) {
     companion object {
         fun getDefaultState() = HomeState(
             lastDiagnosisDate = "",
             chartViewType = ChartViewType.DAY,
+            diagnosisHistories = emptyList(),
         )
     }
 }

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/home/HomeViewModel.kt
@@ -3,7 +3,6 @@ package com.signal.signal_android.feature.main.home
 import androidx.lifecycle.viewModelScope
 import com.signal.domain.entity.DiagnosisHistoryEntity
 import com.signal.domain.enums.ChartViewType
-import com.signal.domain.repository.DiagnosisRepository
 import com.signal.domain.usecase.users.GetAccountIdUseCase
 import com.signal.domain.usecase.users.GetDiagnosisHistoriesUseCase
 import com.signal.signal_android.BaseViewModel
@@ -35,7 +34,8 @@ internal class HomeViewModel(
                 setState(
                     state.value.copy(
                         diagnosisHistories = diagnosisHistories.map { it.copy(date = it.date.split("-")[2]) },
-                        lastDiagnosisDate = diagnosisHistories.last().date.toLastDiagnosisDate(),
+                        lastDiagnosisDate = diagnosisHistories.lastOrNull()?.date?.toLastDiagnosisDate()
+                            ?: "",
                     )
                 )
             }

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/home/HomeViewModel.kt
@@ -1,5 +1,6 @@
 package com.signal.signal_android.feature.main.home
 
+import com.signal.domain.enums.ChartViewType
 import com.signal.domain.repository.DiagnosisRepository
 import com.signal.signal_android.BaseViewModel
 
@@ -14,5 +15,35 @@ internal class HomeViewModel(
         diagnosisRepository.getLastDiagnosisDate().onSuccess {
             setState(state.value.copy(lastDiagnosisDate = it))
         }.onFailure { }
+    }
+
+    internal fun nextChartViewType() {
+        with(state.value) {
+            val currentChartViewTypeIndex = chartViewType.ordinal
+            setState(
+                copy(
+                    chartViewType = if (currentChartViewTypeIndex != ChartViewType.values().lastIndex) {
+                        ChartViewType.values()[currentChartViewTypeIndex + 1]
+                    } else {
+                        ChartViewType.values().first()
+                    }
+                )
+            )
+        }
+    }
+
+    internal fun previousChartViewType() {
+        with(state.value) {
+            val currentChartViewTypeIndex = chartViewType.ordinal
+            setState(
+                copy(
+                    chartViewType = if (currentChartViewTypeIndex != 0) {
+                        ChartViewType.values()[currentChartViewTypeIndex - 1]
+                    } else {
+                        ChartViewType.values().last()
+                    }
+                )
+            )
+        }
     }
 }

--- a/presentation/src/main/java/com/signal/signal_android/feature/main/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/signal/signal_android/feature/main/home/HomeViewModel.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 internal class HomeViewModel(
-    private val diagnosisRepository: DiagnosisRepository,
     private val getDiagnosisHistoriesUseCase: GetDiagnosisHistoriesUseCase,
     private val getAccountIdUseCase: GetAccountIdUseCase,
 ) : BaseViewModel<HomeState, HomeSideEffect>(HomeState.getDefaultState()) {
@@ -51,12 +50,6 @@ internal class HomeViewModel(
         append(this@toLastDiagnosisDate.substring(8..9))
         append("일 ")
     }.toString()
-
-    private fun getLastDiagnosisDate() {
-        diagnosisRepository.getLastDiagnosisDate().onSuccess {
-            setState(state.value.copy(lastDiagnosisDate = it))
-        }
-    }
 
     internal fun nextChartViewType() {
         with(state.value) {


### PR DESCRIPTION
## 개요
> 우울증 수치 내역과 홈 스크린 차트를 연동했습니다.

## 작업사항
- 내역 가공 로직 구현

## 추가 로 할 말
